### PR TITLE
Plugin: pin bound conversation summary message

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -13,10 +13,12 @@ function makeStateDir(): string {
 function createApiMock() {
   const stateDir = makeStateDir();
   const sendComponentMessage = vi.fn(async () => ({}));
-  const sendMessageDiscord = vi.fn(async () => ({}));
-  const sendMessageTelegram = vi.fn(async () => ({}));
+  const sendMessageDiscord = vi.fn(async () => ({ messageId: "discord-msg-1", channelId: "channel:chan-1" }));
+  const sendMessageTelegram = vi.fn(async () => ({ messageId: "1", chatId: "123" }));
   const discordTypingStart = vi.fn(async () => ({ refresh: vi.fn(async () => {}), stop: vi.fn() }));
   const renameTopic = vi.fn(async () => ({}));
+  const resolveTelegramToken = vi.fn(() => ({ token: "telegram-token", source: "config" }));
+  const editChannel = vi.fn(async () => ({}));
   const api = {
     id: "test-plugin",
     pluginConfig: {
@@ -46,6 +48,7 @@ function createApiMock() {
         },
         telegram: {
           sendMessageTelegram,
+          resolveTelegramToken,
           typing: {
             start: vi.fn(async () => ({ refresh: vi.fn(async () => {}), stop: vi.fn() })),
           },
@@ -60,7 +63,7 @@ function createApiMock() {
             start: discordTypingStart,
           },
           conversationActions: {
-            editChannel: vi.fn(async () => ({})),
+            editChannel,
           },
         },
       },
@@ -78,6 +81,8 @@ function createApiMock() {
     sendMessageTelegram,
     discordTypingStart,
     renameTopic,
+    resolveTelegramToken,
+    editChannel,
     stateDir,
   };
 }
@@ -90,6 +95,8 @@ async function createControllerHarness() {
     sendMessageTelegram,
     discordTypingStart,
     renameTopic,
+    resolveTelegramToken,
+    editChannel,
     stateDir,
   } = createApiMock();
   const controller = new CodexPluginController(api);
@@ -145,6 +152,8 @@ async function createControllerHarness() {
     sendMessageTelegram,
     discordTypingStart,
     renameTopic,
+    resolveTelegramToken,
+    editChannel,
     stateDir,
   };
 }
@@ -204,10 +213,19 @@ function buildTelegramCommandContext(
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 beforeEach(() => {
   vi.spyOn(CodexAppServerClient.prototype, "logStartupProbe").mockResolvedValue();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    })),
+  );
 });
 
 async function flushAsyncWork(): Promise<void> {
@@ -660,7 +678,7 @@ describe("Discord controller flows", () => {
   });
 
   it("parses unicode em dash --sync for codex_resume and renames the Telegram topic", async () => {
-    const { controller, renameTopic } = await createControllerHarness();
+    const { controller, renameTopic, sendMessageTelegram } = await createControllerHarness();
 
     const reply = await controller.handleCommand(
       "codex_resume",
@@ -677,7 +695,128 @@ describe("Discord controller flows", () => {
       "Discord Thread (openclaw)",
       expect.objectContaining({ accountId: "default" }),
     );
-    expect(reply.text).toContain("Codex thread bound.");
+    expect(reply).toEqual({});
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("Thread Name: Discord Thread"),
+      expect.objectContaining({ accountId: "default", messageThreadId: 456 }),
+    );
+  });
+
+  it("pins the Telegram binding summary message on resume and unpins it on detach", async () => {
+    const { controller } = await createControllerHarness();
+    const fetchMock = vi.mocked(fetch);
+
+    await controller.handleCommand(
+      "codex_resume",
+      buildTelegramCommandContext({
+        args: "thread-1",
+        commandBody: "/codex_resume thread-1",
+        messageThreadId: 456,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottelegram-token/pinChatMessage",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual(
+      expect.objectContaining({
+        chat_id: "123",
+        message_id: 1,
+      }),
+    );
+    expect(
+      (controller as any).store.getBinding({
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "123:topic:456",
+        parentConversationId: "123",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        pinnedBindingMessage: {
+          provider: "telegram",
+          messageId: "1",
+          chatId: "123",
+        },
+      }),
+    );
+
+    await controller.handleCommand(
+      "codex_detach",
+      buildTelegramCommandContext({
+        commandBody: "/codex_detach",
+        messageThreadId: 456,
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "binding-1" })),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottelegram-token/unpinChatMessage",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("pins the Discord binding summary message on resume and unpins it on detach", async () => {
+    const { controller } = await createControllerHarness();
+    const fetchMock = vi.mocked(fetch);
+    vi.spyOn(controller as any, "resolveDiscordBotToken").mockResolvedValue("discord-token");
+
+    await controller.handleCommand(
+      "codex_resume",
+      buildDiscordCommandContext({
+        args: "thread-1",
+        commandBody: "/codex_resume thread-1",
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel%3Achan-1/pins/discord-msg-1",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          Authorization: "Bot discord-token",
+        }),
+      }),
+    );
+    expect(
+      (controller as any).store.getBinding({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        pinnedBindingMessage: {
+          provider: "discord",
+          messageId: "discord-msg-1",
+          channelId: "channel:chan-1",
+        },
+      }),
+    );
+
+    await controller.handleCommand(
+      "codex_detach",
+      buildDiscordCommandContext({
+        commandBody: "/codex_detach",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "binding-1" })),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel%3Achan-1/pins/discord-msg-1",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          Authorization: "Bot discord-token",
+        }),
+      }),
+    );
   });
 
   it("replays pending codex_resume --sync effects after approval hydrates on the next resume command", async () => {
@@ -735,7 +874,12 @@ describe("Discord controller flows", () => {
       "Discord Thread (openclaw)",
       expect.objectContaining({ accountId: "default" }),
     );
-    expect(hydratedReply.text).toContain("Codex thread bound.");
+    expect(hydratedReply).toEqual({});
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("Thread Name: Discord Thread"),
+      expect.objectContaining({ accountId: "default", messageThreadId: 456 }),
+    );
     expect(sendMessageTelegram).toHaveBeenCalledWith(
       "123",
       "Last User Request in Thread:",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -14,6 +14,7 @@ import type {
   ReplyPayload,
   ConversationRef,
 } from "openclaw/plugin-sdk";
+import { resolveDiscordAccount } from "openclaw/plugin-sdk/discord";
 import { resolvePluginSettings, resolveWorkspaceDir } from "./config.js";
 import { CodexAppServerClient, type ActiveCodexRun, isMissingThreadError } from "./client.js";
 import {
@@ -111,11 +112,6 @@ type ScopedBindingApi = {
   getCurrentConversationBinding?: () => Promise<unknown>;
 };
 
-type FollowUpSummary = {
-  initialReply: ReplyPayload;
-  followUps: string[];
-};
-
 type HydratedBindingResult = {
   binding: StoredBinding;
   pendingBind?: StoredPendingBind;
@@ -126,6 +122,18 @@ type PlanDelivery = {
   attachmentPath?: string;
   attachmentFallbackText?: string;
 };
+
+type DeliveredMessageRef =
+  | {
+      provider: "telegram";
+      messageId: string;
+      chatId: string;
+    }
+  | {
+      provider: "discord";
+      messageId: string;
+      channelId: string;
+    };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -546,6 +554,7 @@ export class CodexPluginController {
   private readonly threadChangesCache = new Map<string, Promise<boolean | undefined>>();
   private readonly store;
   private serviceWorkspaceDir?: string;
+  private lastRuntimeConfig?: unknown;
   private started = false;
 
   constructor(private readonly api: OpenClawPluginApi) {
@@ -888,6 +897,7 @@ export class CodexPluginController {
 
   async handleCommand(commandName: string, ctx: PluginCommandContext): Promise<ReplyPayload> {
     await this.start();
+    this.lastRuntimeConfig = ctx.config;
     const bindingApi = asScopedBindingApi(ctx);
     const conversation = toConversationTargetFromCommand(ctx);
     const currentBinding =
@@ -1021,9 +1031,8 @@ export class CodexPluginController {
           await this.renameConversationIfSupported(conversation, syncedName);
         }
       }
-      const summary = await this.buildBoundConversationSummaryReply(conversation);
-      this.queueFollowUpTexts(conversation, summary.followUps);
-      return summary.initialReply;
+      await this.sendBoundConversationSummary(conversation);
+      return {};
     }
     if (parsed.listProjects || !parsed.query) {
       const passthroughArgs = [
@@ -1090,9 +1099,8 @@ export class CodexPluginController {
         await this.renameConversationIfSupported(conversation, syncedName);
       }
     }
-    const summary = await this.buildBoundConversationSummaryReply(conversation);
-    this.queueFollowUpTexts(conversation, summary.followUps);
-    return summary.initialReply;
+    await this.sendBoundConversationSummary(conversation);
+    return {};
   }
 
   private async handleStatusCommand(
@@ -2975,6 +2983,7 @@ export class CodexPluginController {
     },
   ): Promise<StoredBinding> {
     const sessionKey = buildPluginSessionKey(params.threadId);
+    const existing = this.store.getBinding(conversation);
     const record: StoredBinding = {
       conversation: {
         channel: conversation.channel,
@@ -2986,7 +2995,8 @@ export class CodexPluginController {
       threadId: params.threadId,
       workspaceDir: params.workspaceDir,
       threadTitle: params.threadTitle,
-      contextUsage: this.store.getBinding(conversation)?.contextUsage,
+      pinnedBindingMessage: existing?.pinnedBindingMessage,
+      contextUsage: existing?.contextUsage,
       updatedAt: Date.now(),
     };
     await this.store.upsertBinding(record);
@@ -3171,35 +3181,14 @@ export class CodexPluginController {
       parentConversationId: conversation.parentConversationId,
       threadId: "threadId" in conversation ? conversation.threadId : undefined,
     };
-    for (const message of messages) {
+    const [firstMessage, ...followUps] = messages;
+    if (firstMessage) {
+      const delivered = await this.sendTextWithDeliveryRef(target, firstMessage);
+      await this.pinBindingMessage(target, delivered);
+    }
+    for (const message of followUps) {
       await this.sendText(target, message);
     }
-  }
-
-  private async buildBoundConversationSummaryReply(
-    conversation: ConversationTarget | ConversationRef,
-  ): Promise<FollowUpSummary> {
-    const messages = await this.buildBoundConversationMessages(conversation);
-    const [firstMessage, ...followUps] = messages;
-    return {
-      initialReply: buildPlainReply(firstMessage ?? "Codex thread bound."),
-      followUps,
-    };
-  }
-
-  private queueFollowUpTexts(conversation: ConversationTarget, texts: string[]): void {
-    if (texts.length === 0) {
-      return;
-    }
-    setTimeout(() => {
-      void (async () => {
-        for (const text of texts) {
-          await this.sendText(conversation, text);
-        }
-      })().catch((error) => {
-        this.api.logger.warn(`codex follow-up send failed: ${String(error)}`);
-      });
-    }, 0);
   }
 
   private async buildStatusText(
@@ -3484,6 +3473,10 @@ export class CodexPluginController {
   }
 
   private async unbindConversation(conversation: ConversationTarget): Promise<void> {
+    const binding = this.store.getBinding(conversation);
+    if (binding?.pinnedBindingMessage) {
+      await this.unpinStoredBindingMessage(binding);
+    }
     await this.store.removeBinding(conversation);
   }
 
@@ -3524,6 +3517,219 @@ export class CodexPluginController {
       text,
       buttons: opts?.buttons,
     });
+  }
+
+  private async sendTextWithDeliveryRef(
+    conversation: ConversationTarget,
+    text: string,
+  ): Promise<DeliveredMessageRef | null> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return null;
+    }
+    if (isTelegramChannel(conversation.channel)) {
+      const limit = this.api.runtime.channel.text.resolveTextChunkLimit(
+        undefined,
+        "telegram",
+        conversation.accountId,
+        { fallbackLimit: 4000 },
+      );
+      const chunks = this.api.runtime.channel.text.chunkText(trimmed, limit).filter(Boolean);
+      const textChunks = chunks.length > 0 ? chunks : [trimmed];
+      let firstDelivered: DeliveredMessageRef | null = null;
+      for (const chunk of textChunks) {
+        const result = await this.api.runtime.channel.telegram.sendMessageTelegram(
+          conversation.parentConversationId ?? conversation.conversationId,
+          chunk,
+          {
+            accountId: conversation.accountId,
+            messageThreadId: conversation.threadId,
+          },
+        );
+        if (!firstDelivered) {
+          firstDelivered = {
+            provider: "telegram",
+            messageId: result.messageId,
+            chatId: result.chatId,
+          };
+        }
+      }
+      return firstDelivered;
+    }
+    if (isDiscordChannel(conversation.channel)) {
+      const limit = this.api.runtime.channel.text.resolveTextChunkLimit(
+        undefined,
+        "discord",
+        conversation.accountId,
+        { fallbackLimit: 2000 },
+      );
+      const chunks = this.api.runtime.channel.text.chunkText(trimmed, limit).filter(Boolean);
+      const textChunks = chunks.length > 0 ? chunks : [trimmed];
+      let firstDelivered: DeliveredMessageRef | null = null;
+      for (const chunk of textChunks) {
+        const result = await this.api.runtime.channel.discord.sendMessageDiscord(
+          conversation.conversationId,
+          chunk,
+          {
+            accountId: conversation.accountId,
+          },
+        );
+        if (!firstDelivered) {
+          firstDelivered = {
+            provider: "discord",
+            messageId: result.messageId,
+            channelId: result.channelId,
+          };
+        }
+      }
+      return firstDelivered;
+    }
+    await this.sendText(conversation, trimmed);
+    return null;
+  }
+
+  private async pinBindingMessage(
+    conversation: ConversationTarget,
+    delivered: DeliveredMessageRef | null,
+  ): Promise<void> {
+    if (!delivered) {
+      return;
+    }
+    const binding = this.store.getBinding(conversation);
+    if (!binding) {
+      return;
+    }
+    if (binding.pinnedBindingMessage) {
+      await this.unpinStoredBindingMessage(binding).catch(() => undefined);
+    }
+    try {
+      if (delivered.provider === "telegram") {
+        const token = await this.resolveTelegramBotToken(conversation.accountId);
+        if (!token) {
+          this.api.logger.debug?.(
+            `codex telegram pin skipped ${this.formatConversationForLog(conversation)} reason=no-token`,
+          );
+          return;
+        }
+        await this.callTelegramPinApi("pinChatMessage", token, {
+          chat_id: delivered.chatId,
+          message_id: Number(delivered.messageId),
+          disable_notification: true,
+        });
+      } else {
+        const token = await this.resolveDiscordBotToken(conversation.accountId);
+        if (!token) {
+          this.api.logger.debug?.(
+            `codex discord pin skipped ${this.formatConversationForLog(conversation)} reason=no-token`,
+          );
+          return;
+        }
+        await this.callDiscordPinApi("pin", token, delivered.channelId, delivered.messageId);
+      }
+      await this.store.upsertBinding({
+        ...binding,
+        pinnedBindingMessage: delivered,
+        updatedAt: Date.now(),
+      });
+    } catch (error) {
+      this.api.logger.warn(`codex binding message pin failed: ${String(error)}`);
+    }
+  }
+
+  private async unpinStoredBindingMessage(binding: StoredBinding): Promise<void> {
+    const pinned = binding.pinnedBindingMessage;
+    if (!pinned) {
+      return;
+    }
+    try {
+      if (pinned.provider === "telegram") {
+        const token = await this.resolveTelegramBotToken(binding.conversation.accountId);
+        if (!token) {
+          this.api.logger.debug?.(
+            `codex telegram unpin skipped conversation=${binding.conversation.conversationId} reason=no-token`,
+          );
+          return;
+        }
+        await this.callTelegramPinApi("unpinChatMessage", token, {
+          chat_id: pinned.chatId,
+          message_id: Number(pinned.messageId),
+        });
+      } else {
+        const token = await this.resolveDiscordBotToken(binding.conversation.accountId);
+        if (!token) {
+          this.api.logger.debug?.(
+            `codex discord unpin skipped conversation=${binding.conversation.conversationId} reason=no-token`,
+          );
+          return;
+        }
+        await this.callDiscordPinApi("unpin", token, pinned.channelId, pinned.messageId);
+      }
+    } catch (error) {
+      this.api.logger.warn(`codex binding message unpin failed: ${String(error)}`);
+    }
+  }
+
+  private async resolveTelegramBotToken(accountId?: string): Promise<string | undefined> {
+    const resolution = this.api.runtime.channel.telegram.resolveTelegramToken?.(
+      this.lastRuntimeConfig,
+      { accountId },
+    );
+    const token = resolution?.token?.trim();
+    return token || undefined;
+  }
+
+  private async resolveDiscordBotToken(accountId?: string): Promise<string | undefined> {
+    const cfg = this.lastRuntimeConfig;
+    if (!cfg) {
+      return undefined;
+    }
+    const account = resolveDiscordAccount({
+      cfg: cfg as Parameters<typeof resolveDiscordAccount>[0]["cfg"],
+      accountId,
+    });
+    const token = account.token?.trim();
+    return token || undefined;
+  }
+
+  private async callDiscordPinApi(
+    action: "pin" | "unpin",
+    token: string,
+    channelId: string,
+    messageId: string,
+  ): Promise<void> {
+    const response = await fetch(
+      `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/pins/${encodeURIComponent(messageId)}`,
+      {
+        method: action === "pin" ? "PUT" : "DELETE",
+        headers: {
+          Authorization: `Bot ${token}`,
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Discord ${action} failed status=${response.status} body=${await response.text()}`,
+      );
+    }
+  }
+
+  private async callTelegramPinApi(
+    method: "pinChatMessage" | "unpinChatMessage",
+    token: string,
+    body: Record<string, unknown>,
+  ): Promise<void> {
+    const response = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Telegram ${method} failed status=${response.status} body=${await response.text()}`,
+      );
+    }
   }
 
   private async renameConversationIfSupported(

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -192,7 +192,15 @@ declare module "openclaw/plugin-sdk" {
               textMode?: "markdown" | "html";
               buttons?: PluginInteractiveButtons;
             },
-          ) => Promise<unknown>;
+          ) => Promise<{ messageId: string; chatId: string }>;
+          resolveTelegramToken: (
+            cfg?: unknown,
+            opts?: {
+              envToken?: string | null;
+              accountId?: string | null;
+              logMissingFile?: (message: string) => void;
+            },
+          ) => { token: string; source: string };
           typing: {
             start: (params: {
               to: string;
@@ -218,7 +226,7 @@ declare module "openclaw/plugin-sdk" {
               mediaUrl?: string;
               mediaLocalRoots?: readonly string[];
             },
-          ) => Promise<unknown>;
+          ) => Promise<{ messageId: string; channelId: string }>;
           sendComponentMessage: (
             to: string,
             spec: unknown,

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,6 +244,17 @@ export type StoredBinding = {
   threadId: string;
   workspaceDir: string;
   threadTitle?: string;
+  pinnedBindingMessage?:
+    | {
+        provider: "telegram";
+        messageId: string;
+        chatId: string;
+      }
+    | {
+        provider: "discord";
+        messageId: string;
+        channelId: string;
+      };
   contextUsage?: ContextUsageSnapshot;
   updatedAt: number;
 };


### PR DESCRIPTION
## Summary
- pin the bound-thread summary message on `/codex_resume` for Telegram and Discord when the provider supports it
- persist the pinned message metadata so `/codex_detach` can best-effort unpin it later
- add regression coverage for Telegram and Discord pin/unpin flows and the resume summary delivery path

## Validation
- pnpm test
- pnpm typecheck

### Pin on `/codex_resume`

<img width="930" height="909" alt="image" src="https://github.com/user-attachments/assets/7e32d8ed-5942-4b72-b4b4-c5a85ccaf184" />

<img width="930" height="909" alt="image" src="https://github.com/user-attachments/assets/e46a7353-f05a-4fe9-86c2-02c6cca46db9" />

### Unpin on `/codex_detach`

<img width="930" height="909" alt="image" src="https://github.com/user-attachments/assets/e4789a69-a92d-4711-ada5-b736af4a505b" />
