### PR TITLE
Plugin: stop treating approval cancel as auth failure

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -458,3 +458,90 @@ describe("createPendingInputCoordinator", () => {
     await expect(second.response).resolves.toEqual({ index: 0, option: "approve" });
   });
 });
+
+describe("turn stop detection", () => {
+  it("treats silent approval cancels as an approval stop reason", () => {
+    expect(
+      __testing.resolveTurnStoppedReason({
+        interrupted: false,
+        terminalStatus: "completed",
+        approvalCancelled: true,
+        assistantText: "",
+        hasPlanArtifact: false,
+      }),
+    ).toBe("approval");
+  });
+
+  it("does not hide assistant output after an approval cancel", () => {
+    expect(
+      __testing.resolveTurnStoppedReason({
+        interrupted: false,
+        terminalStatus: "completed",
+        approvalCancelled: true,
+        assistantText: "Cancelled, but here is context.",
+        hasPlanArtifact: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps explicit turn cancellations distinct from approval cancels", () => {
+    expect(
+      __testing.resolveTurnStoppedReason({
+        interrupted: false,
+        terminalStatus: "interrupted",
+        approvalCancelled: false,
+        assistantText: "",
+        hasPlanArtifact: false,
+      }),
+    ).toBe("cancelled");
+  });
+});
+
+describe("extractTurnTerminalState", () => {
+  it("parses failed turn/completed notifications with unauthorized details", () => {
+    expect(
+      __testing.extractTurnTerminalState("turn/completed", {
+        turn: {
+          id: "turn-1",
+          status: "failed",
+          error: {
+            message: "unauthorized",
+            codexErrorInfo: "unauthorized",
+          },
+        },
+      }),
+    ).toEqual({
+      status: "failed",
+      error: {
+        message: "unauthorized",
+        codexErrorInfo: "unauthorized",
+        httpStatusCode: undefined,
+      },
+    });
+  });
+
+  it("extracts upstream http status codes from nested codex error info", () => {
+    expect(
+      __testing.extractTurnTerminalState("turn/completed", {
+        turn: {
+          status: "failed",
+          error: {
+            message: "request failed",
+            codexErrorInfo: {
+              httpConnectionFailed: {
+                httpStatusCode: 401,
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      status: "failed",
+      error: {
+        message: "request failed",
+        codexErrorInfo: "httpConnectionFailed:401",
+        httpStatusCode: 401,
+      },
+    });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ import type {
   ThreadReplay,
   ThreadState,
   ThreadSummary,
+  TurnTerminalError,
   TurnResult,
 } from "./types.js";
 
@@ -158,6 +159,19 @@ function pickFiniteNumber(record: Record<string, unknown>, keys: string[]): numb
       if (Number.isFinite(parsed)) {
         return parsed;
       }
+    }
+  }
+  return undefined;
+}
+
+function parseFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) {
+      return parsed;
     }
   }
   return undefined;
@@ -329,6 +343,38 @@ function findFirstNestedValue(value: unknown, keys: readonly string[], depth = 0
   }
   for (const nested of Object.values(record)) {
     const match = findFirstNestedValue(nested, keys, depth + 1);
+    if (match !== undefined) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function findFirstNestedNumber(value: unknown, keys: readonly string[], depth = 0): number | undefined {
+  if (depth > 6) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const match = findFirstNestedNumber(entry, keys, depth + 1);
+      if (match !== undefined) {
+        return match;
+      }
+    }
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const parsed = parseFiniteNumber(record[key]);
+    if (parsed !== undefined) {
+      return parsed;
+    }
+  }
+  for (const nested of Object.values(record)) {
+    const match = findFirstNestedNumber(nested, keys, depth + 1);
     if (match !== undefined) {
       return match;
     }
@@ -2022,6 +2068,98 @@ function extractContextCompactionProgress(
   };
 }
 
+function normalizeTurnTerminalStatus(
+  value: string | undefined,
+): TurnResult["terminalStatus"] | undefined {
+  const normalized = value?.trim().toLowerCase();
+  switch (normalized) {
+    case "completed":
+      return "completed";
+    case "interrupted":
+    case "cancelled":
+    case "canceled":
+      return "interrupted";
+    case "failed":
+    case "error":
+      return "failed";
+    default:
+      return undefined;
+  }
+}
+
+function summarizeCodexErrorInfo(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() || undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  for (const [key, nested] of Object.entries(record)) {
+    const nestedRecord = asRecord(nested);
+    const httpStatusCode = nestedRecord
+      ? pickFiniteNumber(nestedRecord, ["httpStatusCode", "http_status_code"])
+      : undefined;
+    if (httpStatusCode !== undefined) {
+      return `${key}:${httpStatusCode}`;
+    }
+    const nestedSummary = summarizeCodexErrorInfo(nested);
+    if (nestedSummary) {
+      return `${key}:${nestedSummary}`;
+    }
+    return key;
+  }
+  return undefined;
+}
+
+function extractTurnTerminalState(
+  method: string,
+  params: unknown,
+): { status?: TurnResult["terminalStatus"]; error?: TurnTerminalError } | undefined {
+  const methodLower = method.trim().toLowerCase();
+  if (
+    methodLower !== "turn/completed" &&
+    methodLower !== "turn/failed" &&
+    methodLower !== "turn/cancelled"
+  ) {
+    return undefined;
+  }
+  const record = asRecord(params) ?? {};
+  const turn = asRecord(record.turn) ?? record;
+  const errorRecord = asRecord(turn.error) ?? asRecord(record.error) ?? null;
+  const status =
+    normalizeTurnTerminalStatus(
+      pickString(turn, ["status"]) ??
+        (methodLower === "turn/failed"
+          ? "failed"
+          : methodLower === "turn/cancelled"
+            ? "interrupted"
+            : "completed"),
+    ) ??
+    (methodLower === "turn/failed"
+      ? "failed"
+      : methodLower === "turn/cancelled"
+        ? "interrupted"
+        : undefined);
+  if (!errorRecord) {
+    return { status };
+  }
+  const codexErrorInfoValue =
+    errorRecord.codexErrorInfo ?? errorRecord.codex_error_info ?? errorRecord.type;
+  const error: TurnTerminalError = {
+    message:
+      pickString(errorRecord, ["message", "text", "summary", "reason"], { trim: true }) ??
+      undefined,
+    codexErrorInfo: summarizeCodexErrorInfo(codexErrorInfoValue),
+    httpStatusCode: findFirstNestedNumber(codexErrorInfoValue, ["httpStatusCode", "http_status_code"]),
+  };
+  return {
+    status,
+    error:
+      error.message || error.codexErrorInfo || error.httpStatusCode !== undefined ? error : undefined,
+  };
+}
+
 function mapPendingInputResponse(params: {
   methodLower: string;
   requestParams: unknown;
@@ -2059,6 +2197,30 @@ function mapPendingInputResponse(params: {
     return { cancelled: true, reason: "timeout" };
   }
   return response;
+}
+
+function extractApprovalDecision(value: unknown): string | undefined {
+  const record = asRecord(value);
+  return record ? pickString(record, ["decision"]) : undefined;
+}
+
+function resolveTurnStoppedReason(params: {
+  interrupted: boolean;
+  terminalStatus?: TurnResult["terminalStatus"];
+  approvalCancelled: boolean;
+  assistantText: string;
+  hasPlanArtifact: boolean;
+}): TurnResult["stoppedReason"] | undefined {
+  if (params.interrupted) {
+    return "interrupt";
+  }
+  if (params.terminalStatus === "interrupted") {
+    return "cancelled";
+  }
+  if (params.approvalCancelled && !params.assistantText.trim() && !params.hasPlanArtifact) {
+    return "approval";
+  }
+  return undefined;
 }
 
 type PendingInputQueueEntry = {
@@ -2953,6 +3115,9 @@ export class CodexAppServerClient {
     let interrupted = false;
     let completed = false;
     let latestContextUsage: ContextUsageSnapshot | undefined;
+    let terminalStatus: TurnResult["terminalStatus"] | undefined;
+    let terminalError: TurnTerminalError | undefined;
+    let approvalCancelled = false;
     let notificationQueue = Promise.resolve();
     const pendingInputCoordinator = createPendingInputCoordinator({
       inputTimeoutMs: this.settings.inputTimeoutMs,
@@ -3069,6 +3234,9 @@ export class CodexAppServerClient {
           methodLower === "turn/failed" ||
           methodLower === "turn/cancelled"
         ) {
+          const terminalState = extractTurnTerminalState(method, notificationParams);
+          terminalStatus = terminalState?.status ?? terminalStatus;
+          terminalError = terminalState?.error ?? terminalError;
           await fileEditNoticeBatcher.flush();
           this.logger.debug(
             `codex turn terminal notification run=${params.runId} thread=${threadId || "<pending>"} turn=${turnId || "<pending>"} method=${methodLower}`,
@@ -3136,6 +3304,13 @@ export class CodexAppServerClient {
         actions: state.actions ?? [],
         timedOut: pendingEntry.timedOut,
       });
+      const approvalDecision = extractApprovalDecision(mappedResponse)?.toLowerCase();
+      if (approvalDecision === "cancel") {
+        approvalCancelled = true;
+        this.logger.debug(
+          `codex turn approval cancelled by user run=${params.runId} thread=${threadId || "<none>"} turn=${turnId || "<none>"} method=${methodLower}`,
+        );
+      }
       const responseRecord = asRecord(response);
       const steerText =
         methodLower.includes("requestapproval") && typeof responseRecord?.steerText === "string"
@@ -3216,6 +3391,14 @@ export class CodexAppServerClient {
         this.logger.debug(
           `codex turn completion settled run=${params.runId} thread=${threadId || "<none>"} turn=${turnId || "<none>"} interrupted=${interrupted ? "yes" : "no"} assistantChars=${assistantText.length}`,
         );
+        const stoppedReason = resolveTurnStoppedReason({
+          interrupted,
+          terminalStatus,
+          approvalCancelled,
+          assistantText,
+          hasPlanArtifact:
+            Boolean(finalPlanMarkdown) || planDraftByItemId.size > 0 || planSteps.length > 0,
+        });
         return {
           threadId,
           text:
@@ -3229,7 +3412,10 @@ export class CodexAppServerClient {
                 markdown: finalPlanMarkdown,
               }
             : undefined,
-          aborted: interrupted,
+          aborted: stoppedReason === "interrupt" || stoppedReason === "cancelled",
+          stoppedReason,
+          terminalStatus,
+          terminalError,
           usage: latestContextUsage,
         } satisfies TurnResult;
       } catch (error) {
@@ -3365,6 +3551,8 @@ export const __testing = {
   buildTurnSteerPayloads,
   createFileEditNoticeBatcher,
   createPendingInputCoordinator,
+  extractApprovalDecision,
+  extractTurnTerminalState,
   extractFileEditSummariesFromNotification,
   extractFileChangePathsFromReadResult,
   extractStartupProbeInfo,
@@ -3372,4 +3560,5 @@ export const __testing = {
   extractThreadTokenUsageSnapshot,
   extractRateLimitSummaries,
   formatStdioProcessLog,
+  resolveTurnStoppedReason,
 };

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -1939,16 +1939,17 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("maps empty completed turns to the same re-login guidance when Codex now requires auth", async () => {
+  it("surfaces explicit failed turns as auth failures when the terminal error is unauthorized", async () => {
     const { controller, clientMock, sendMessageTelegram } = await createControllerHarness();
-    clientMock.readAccount.mockResolvedValue({
-      type: "chatgpt",
-      requiresOpenaiAuth: true,
-    } as any);
     (controller as any).client.startTurn = vi.fn(() => ({
       result: Promise.resolve({
         threadId: "thread-1",
-        text: "",
+        terminalStatus: "failed",
+        terminalError: {
+          message: "unauthorized",
+          codexErrorInfo: "unauthorized",
+          httpStatusCode: 401,
+        },
       }),
       getThreadId: () => "thread-1",
       queueMessage: vi.fn(async () => false),
@@ -1986,5 +1987,102 @@ describe("Discord controller flows", () => {
       "Codex authentication failed on this machine. Run `codex logout` and `codex login`, then try again.",
       expect.anything(),
     );
+    expect(clientMock.readAccount).toHaveBeenCalledWith({
+      sessionKey: "session-1",
+      refreshToken: true,
+    });
+  });
+
+  it("keeps empty completed turns generic instead of inferring an auth failure", async () => {
+    const { controller, clientMock, sendMessageTelegram } = await createControllerHarness();
+    (controller as any).client.startTurn = vi.fn(() => ({
+      result: Promise.resolve({
+        threadId: "thread-1",
+        text: "",
+        terminalStatus: "completed",
+      }),
+      getThreadId: () => "thread-1",
+      queueMessage: vi.fn(async () => false),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+
+    await (controller as any).startTurn({
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "8460800771",
+      },
+      binding: {
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "8460800771",
+        },
+        sessionKey: "session-1",
+        threadId: "thread-1",
+        workspaceDir: "/repo/openclaw",
+        updatedAt: Date.now(),
+      },
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "inbound",
+    });
+
+    await flushAsyncWork();
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "8460800771",
+      "Codex completed without a text reply.",
+      expect.anything(),
+    );
+    expect(clientMock.readAccount).not.toHaveBeenCalled();
+  });
+
+  it("does not probe auth after an approval cancel completes without assistant text", async () => {
+    const { controller, clientMock, sendMessageTelegram } = await createControllerHarness();
+    (controller as any).client.startTurn = vi.fn(() => ({
+      result: Promise.resolve({
+        threadId: "thread-1",
+        stoppedReason: "approval",
+      }),
+      getThreadId: () => "thread-1",
+      queueMessage: vi.fn(async () => false),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+
+    await (controller as any).startTurn({
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "8460800771",
+      },
+      binding: {
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "8460800771",
+        },
+        sessionKey: "session-1",
+        threadId: "thread-1",
+        workspaceDir: "/repo/openclaw",
+        updatedAt: Date.now(),
+      },
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "inbound",
+    });
+
+    await flushAsyncWork();
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "8460800771",
+      "Cancelled the Codex approval request.",
+      expect.anything(),
+    );
+    expect(clientMock.readAccount).not.toHaveBeenCalled();
   });
 });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -38,7 +38,7 @@ import {
   formatThreadState,
   formatTurnCompletion,
 } from "./format.js";
-import type { AccountSummary, CollaborationMode } from "./types.js";
+import type { AccountSummary, CollaborationMode, TurnTerminalError } from "./types.js";
 import {
   buildPendingQuestionnaireResponse,
   formatPendingQuestionnairePrompt,
@@ -1747,14 +1747,21 @@ export class CodexPluginController {
           }
         }
         this.api.logger.debug?.(
-          `codex turn completed ${this.formatConversationForLog(params.conversation)} thread=${threadId ?? "<none>"} aborted=${result.aborted ? "yes" : "no"} text=${result.text ? "yes" : "no"} plan=${result.planArtifact ? "yes" : "no"}`,
+          `codex turn completed ${this.formatConversationForLog(params.conversation)} thread=${threadId ?? "<none>"} aborted=${result.aborted ? "yes" : "no"} stoppedReason=${result.stoppedReason ?? "none"} terminalStatus=${result.terminalStatus ?? "none"} text=${result.text ? "yes" : "no"} plan=${result.planArtifact ? "yes" : "no"}`,
         );
         const completionText =
-          !result.aborted && !result.text?.trim() && !result.planArtifact?.markdown
-            ? await this.describeEmptyTurnCompletion({
+          result.terminalStatus === "failed"
+            ? await this.describeTurnFailure({
                 sessionKey: params.binding?.sessionKey,
+                error: result.terminalError?.message ?? "turn failed",
+                terminalError: result.terminalError,
               })
-            : formatTurnCompletion(result);
+            : !result.aborted &&
+                result.stoppedReason !== "approval" &&
+                !result.text?.trim() &&
+                !result.planArtifact?.markdown
+              ? await this.describeEmptyTurnCompletion()
+              : formatTurnCompletion(result);
         await this.sendText(params.conversation, completionText);
       })
       .catch(async (error) => {
@@ -1786,21 +1793,30 @@ export class CodexPluginController {
   private async describeTurnFailure(params: {
     sessionKey?: string;
     error: unknown;
+    terminalError?: TurnTerminalError;
   }): Promise<string> {
-    const message = params.error instanceof Error ? params.error.message : String(params.error);
-    const account = await this.client
-      .readAccount({
-        sessionKey: params.sessionKey,
-        refreshToken: true,
-      })
-      .catch(() => undefined);
-    if (account?.requiresOpenaiAuth === true) {
+    const message =
+      params.terminalError?.message?.trim() ||
+      (params.error instanceof Error ? params.error.message : String(params.error));
+    if (this.looksLikeExplicitCodexAuthFailure(params.terminalError, message)) {
+      const account = await this.client
+        .readAccount({
+          sessionKey: params.sessionKey,
+          refreshToken: true,
+        })
+        .catch(() => undefined);
       this.api.logger.warn?.(
-        `codex auth requires login session=${params.sessionKey ?? "<none>"}`,
+        `codex auth failure from terminal turn error session=${params.sessionKey ?? "<none>"}: ${message}`,
       );
       return this.formatCodexAuthFailureMessage(account);
     }
     if (this.looksLikeCodexAuthFailure(message)) {
+      const account = await this.client
+        .readAccount({
+          sessionKey: params.sessionKey,
+          refreshToken: true,
+        })
+        .catch(() => undefined);
       this.api.logger.warn?.(
         `codex auth failure inferred from turn error session=${params.sessionKey ?? "<none>"}: ${message}`,
       );
@@ -1809,21 +1825,7 @@ export class CodexPluginController {
     return `Codex failed: ${message}`;
   }
 
-  private async describeEmptyTurnCompletion(params: {
-    sessionKey?: string;
-  }): Promise<string> {
-    const account = await this.client
-      .readAccount({
-        sessionKey: params.sessionKey,
-        refreshToken: true,
-      })
-      .catch(() => undefined);
-    if (account?.requiresOpenaiAuth === true) {
-      this.api.logger.warn?.(
-        `codex auth requires login after empty turn session=${params.sessionKey ?? "<none>"}`,
-      );
-      return this.formatCodexAuthFailureMessage(account);
-    }
+  private async describeEmptyTurnCompletion(): Promise<string> {
     return "Codex completed without a text reply.";
   }
 
@@ -1849,6 +1851,20 @@ export class CodexPluginController {
       "not signed in",
       "login required",
     ].some((pattern) => normalized.includes(pattern));
+  }
+
+  private looksLikeExplicitCodexAuthFailure(
+    terminalError: TurnTerminalError | undefined,
+    message: string,
+  ): boolean {
+    if (terminalError?.httpStatusCode === 401) {
+      return true;
+    }
+    const codexErrorInfo = terminalError?.codexErrorInfo?.trim().toLowerCase() ?? "";
+    if (codexErrorInfo.includes("unauthorized")) {
+      return true;
+    }
+    return this.looksLikeCodexAuthFailure(message);
   }
 
   private async startPlan(params: {

--- a/src/format.ts
+++ b/src/format.ts
@@ -698,6 +698,9 @@ export function formatTurnCompletion(result: TurnResult): string {
   if (result.text?.trim()) {
     return result.text.trim();
   }
+  if (result.stoppedReason === "approval") {
+    return "Cancelled the Codex approval request.";
+  }
   if (result.aborted) {
     return "Codex turn stopped.";
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,11 +230,20 @@ export type ReviewResult = {
   aborted?: boolean;
 };
 
+export type TurnTerminalError = {
+  message?: string;
+  codexErrorInfo?: string;
+  httpStatusCode?: number;
+};
+
 export type TurnResult = {
   threadId: string;
   text?: string;
   planArtifact?: CodexPlanArtifact;
   aborted?: boolean;
+  stoppedReason?: "interrupt" | "cancelled" | "approval";
+  terminalStatus?: "completed" | "interrupted" | "failed";
+  terminalError?: TurnTerminalError;
   usage?: ContextUsageSnapshot;
 };
 


### PR DESCRIPTION
## Summary
- stop treating approval-request cancel as a broken Codex login
- parse terminal turn status and structured Codex auth error details from turn completion notifications
- prefer explicit failed-turn auth signals over the old empty-turn heuristic
- add regressions for approval cancel and unauthorized terminal turn handling

## Validation
- pnpm test -- --runInBand
- pnpm typecheck
