### PR TITLE
Plugin: add prerelease release workflow

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "Plan and publish a GitHub Release in a tag-driven repository. Use when a user asks to cut, prepare, or publish a software release, propose the next vX.Y.Z tag, draft better release notes from PRs and direct commits since the last release, update CHANGELOG.md, create the tag pinned to an exact commit, and watch the publish workflow."
+description: "Plan and publish a GitHub Release in a tag-driven repository. Use when a user asks to cut, prepare, or publish a stable or prerelease, propose the next vX.Y.Z or vX.Y.Z-beta.N tag, draft better release notes from PRs and direct commits since the last release, update CHANGELOG.md when appropriate, create the tag pinned to an exact commit, and watch the publish workflow."
 ---
 
 # Release
@@ -16,9 +16,12 @@ Use this skill for repos that publish from GitHub Releases and want human-writte
 - Fast-forward the default branch before editing: `git pull --ff-only origin <default-branch>`.
 - Never force-push the default branch.
 - Never use GitHub generated release notes for this workflow.
-- Always create the release tag with a leading `v`, for example `v0.1.0`.
+- Always create the release tag with a leading `v`, for example `v0.1.0` or `v0.2.0-beta.1`.
 - Always pin the release to the exact changelog commit SHA with `gh release create --target <sha>`.
 - If `origin/<default-branch>` moves after planning or before pushing, stop and regenerate the release plan.
+- For prereleases, use a semver prerelease tag that names the npm dist-tag you want, for example `v0.2.0-beta.1` -> npm `beta`.
+- For prereleases, create the GitHub release with `--prerelease`.
+- Prefer leaving `CHANGELOG.md` untouched for prereleases unless the user explicitly wants beta entries there; that keeps later promotion to stable cleaner.
 
 ## Helper Script
 
@@ -26,6 +29,19 @@ Use the bundled planner to gather release facts and raw note inputs:
 
 ```bash
 python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release
+```
+
+Examples:
+
+```bash
+# Plan the next stable release.
+python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release
+
+# Plan the next beta prerelease for the upcoming stable line.
+python3 .agents/skills/release/scripts/release_plan.py --channel beta --output-dir .local/release
+
+# Promote an existing beta tag to a stable release from the same code base.
+python3 .agents/skills/release/scripts/release_plan.py --promote-from v0.2.0-beta.2 --output-dir .local/release
 ```
 
 It writes:
@@ -38,9 +54,11 @@ The planner:
 - finds the latest published semver release
 - counts first-parent commits on the default branch since that release
 - filters leaked release-housekeeping commits such as changelog-only commits
-- proposes the next tag
+- proposes the next stable tag, prerelease tag, or promotion target
 - groups PR-backed changes separately from direct commits on `main`
 - captures contributor mentions for PR-backed items
+- when planning a prerelease, increments tags like `v0.2.0-beta.1`, `v0.2.0-beta.2`, and so on
+- when planning a promotion, pins the plan to the exact prerelease tag commit instead of whatever is now at `origin/<default-branch>`
 
 ## Approval Prompt
 
@@ -49,8 +67,9 @@ Before making any changelog edit, commit, push, tag, or release, show the user:
 - the last release tag
 - the raw and meaningful commit counts since that release
 - the suggested new tag and why
-- whether the change looks like a minor release or a small emergency patch
-- the exact commit SHA currently at `origin/<default-branch>`
+- whether the change looks like a stable minor, a small emergency patch, a prerelease, or a prerelease promotion
+- the exact commit SHA currently targeted by the release plan
+- for prereleases, the npm dist-tag that will be used instead of `latest`
 
 If the meaningful commit count is less than `3`, explicitly warn that there are not many changes in this release and ask whether they still want to proceed.
 
@@ -60,7 +79,7 @@ If the meaningful commit count is less than `3`, explicitly warn that there are 
 - Rewrite each PR-backed item into a clearer user-facing bullet.
 - For direct commits on `main` with no PR, use the commit subject and body as raw input and rewrite those too.
 - Add the PR author mention on the same line for PR-backed entries.
-- Keep the same substance in `CHANGELOG.md` and the GitHub release notes.
+- Keep the same substance in `CHANGELOG.md` and the GitHub release notes for stable releases.
 - Prefer grouped sections such as `Highlights`, `Fixes`, `Performance`, `Docs`, and `Internal` when they fit the release.
 - If `CHANGELOG.md` does not exist, create it with a `# Changelog` header.
 - Insert the new release section at the top, directly under the file header if there is one.
@@ -76,6 +95,9 @@ If the meaningful commit count is less than `3`, explicitly warn that there are 
 docs: add changelog for v0.1.0
 ```
 
+- For prereleases, prefer writing only `.local/release/release-notes.md` and skipping a changelog commit unless the user explicitly wants prerelease changelog entries.
+- For promotion from `vX.Y.Z-beta.N` to `vX.Y.Z`, either tag the same prerelease commit for exact code parity or add only changelog/release-note edits on top before creating the stable tag.
+
 ## Versioning Heuristic
 
 Use the planner's suggestion unless the user overrides it.
@@ -84,6 +106,9 @@ Use the planner's suggestion unless the user overrides it.
 - Use a patch bump only for a small hotfix shortly after the previous release.
 - Treat `v0.9.0` -> `v0.10.0` as the normal next minor bump.
 - Do not jump from `v0.9.0` to `v1.0.0` unless the user explicitly asks.
+- For prereleases, keep the stable base and add a channel suffix such as `v0.2.0-beta.1`.
+- The prerelease channel name becomes the npm dist-tag, so `v0.2.0-beta.1` publishes to `@beta` and does not replace `@latest`.
+- Promotion removes the prerelease suffix: `v0.2.0-beta.2` -> `v0.2.0`.
 
 The bundled planner treats a patch release as the default only when all of these are true:
 
@@ -105,14 +130,27 @@ git pull --ff-only origin "$default_branch"
 python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release
 ```
 
+For a beta prerelease:
+
+```bash
+python3 .agents/skills/release/scripts/release_plan.py --channel beta --output-dir .local/release
+```
+
+For promotion from an existing beta tag:
+
+```bash
+python3 .agents/skills/release/scripts/release_plan.py --promote-from v0.2.0-beta.2 --output-dir .local/release
+```
+
 2. Read `.local/release/release-plan.md` and summarize the proposed release for approval.
 
-3. After approval, write:
+3. After approval:
 
-- `.local/release/release-notes.md`
-- `CHANGELOG.md`
+- always write `.local/release/release-notes.md`
+- for stable releases, update `CHANGELOG.md`
+- for prereleases, skip `CHANGELOG.md` unless the user explicitly wants prerelease changelog entries
 
-4. Commit and push the changelog commit on top of the planned branch tip.
+4. If you updated `CHANGELOG.md`, commit and push the changelog commit on top of the planned source tip.
 
 ```bash
 git add CHANGELOG.md
@@ -121,10 +159,28 @@ git push origin HEAD:"$default_branch"
 release_sha=$(git rev-parse HEAD)
 ```
 
+If you did not update `CHANGELOG.md`, release directly from the planned SHA:
+
+```bash
+release_sha=$(jq -r '.planning.baseSha' .local/release/release-plan.json)
+```
+
 5. Create the release from that exact commit.
+
+Stable:
 
 ```bash
 gh release create "<tag>" \
+  --target "$release_sha" \
+  --title "<tag>" \
+  --notes-file .local/release/release-notes.md
+```
+
+Prerelease:
+
+```bash
+gh release create "<tag>" \
+  --prerelease \
   --target "$release_sha" \
   --title "<tag>" \
   --notes-file .local/release/release-notes.md
@@ -152,3 +208,4 @@ gh run view "$run_id" --log-failed
 - Mention direct-to-main commits that would otherwise be invisible to GitHub's PR-based notes.
 - If the approval gap was long, rerun the planner immediately before editing `CHANGELOG.md`.
 - If the push to the default branch is rejected, stop and regenerate notes from the new branch tip instead of rebasing blindly.
+- For prerelease promotion, do not mix new product commits into the promotion step. Either tag the exact beta commit or keep follow-up changes limited to changelog/release metadata.

--- a/.agents/skills/release/agents/openai.yaml
+++ b/.agents/skills/release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release"
   short_description: "Plan and publish a GitHub release with a real changelog"
-  default_prompt: "Use $release to prepare a GitHub Release, propose the next vX.Y.Z tag, draft better notes than GitHub's defaults, update CHANGELOG.md, and publish from the exact changelog commit."
+  default_prompt: "Use $release to prepare a GitHub release, whether stable or prerelease. Propose the next vX.Y.Z or vX.Y.Z-beta.N tag, draft better notes than GitHub's defaults, update CHANGELOG.md when appropriate, publish from the exact target commit, and preserve an upgrade path from beta to stable on the same code base."

--- a/.agents/skills/release/scripts/release_plan.py
+++ b/.agents/skills/release/scripts/release_plan.py
@@ -15,13 +15,16 @@ from pathlib import Path
 from typing import Any
 
 
-SEMVER_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+STABLE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+PRERELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-([A-Za-z][0-9A-Za-z-]*)(?:\.(\d+))?$")
+CHANNEL_RE = re.compile(r"^[A-Za-z][0-9A-Za-z-]*$")
 CONVENTIONAL_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]+\))?(?P<breaking>!)?: (?P<summary>.+)$")
 TRAILING_PR_RE = re.compile(r"\s+\(#\d+\)$")
 HOUSEKEEPING_SUBJECT_RES = (
     re.compile(r"^docs: (?:add|update|write) changelog\b", re.IGNORECASE),
     re.compile(r"^chore(?:\(release\))?: release\b", re.IGNORECASE),
     re.compile(r"^chore(?:\(release\))?: prepare v\d+\.\d+\.\d+\b", re.IGNORECASE),
+    re.compile(r"^docs: (?:add|update|write) changelog for v\d+\.\d+\.\d+-[A-Za-z][0-9A-Za-z-]*(?:\.\d+)?\b", re.IGNORECASE),
 )
 PATCH_TYPES = {"fix", "docs", "ci", "build", "chore", "deps", "test"}
 FEATURE_TYPES = {"feat", "perf", "refactor"}
@@ -78,6 +81,15 @@ def parse_args() -> argparse.Namespace:
         default=".local/release",
         help="Directory for release-plan.json and release-plan.md (default: .local/release)",
     )
+    parser.add_argument(
+        "--channel",
+        default="stable",
+        help="Release channel to plan. Use stable for normal releases, or a prerelease channel such as beta or rc.",
+    )
+    parser.add_argument(
+        "--promote-from",
+        help="Promote an existing prerelease tag such as v0.3.0-beta.2 to its stable v0.3.0 release.",
+    )
     return parser.parse_args()
 
 
@@ -92,7 +104,7 @@ def current_iso_date() -> str:
 
 
 def parse_semver(tag: str) -> tuple[int, int, int]:
-    match = SEMVER_TAG_RE.match(tag)
+    match = STABLE_TAG_RE.match(tag)
     if not match:
         raise ValueError(f"Unsupported tag format: {tag}")
     return tuple(int(part) for part in match.groups())
@@ -101,6 +113,31 @@ def parse_semver(tag: str) -> tuple[int, int, int]:
 def format_tag(parts: tuple[int, int, int]) -> str:
     major, minor, patch = parts
     return f"v{major}.{minor}.{patch}"
+
+
+def normalize_channel(value: str) -> str:
+    channel = value.strip().lower()
+    if channel == "stable":
+        return channel
+    if not CHANNEL_RE.match(channel):
+        raise ValueError(
+            f"Unsupported release channel: {value}. Use stable or a leading-alphabetic channel such as beta or rc."
+        )
+    return channel
+
+
+def parse_prerelease_tag(tag: str) -> dict[str, Any]:
+    match = PRERELEASE_TAG_RE.match(tag)
+    if not match:
+        raise ValueError(f"Unsupported prerelease tag format: {tag}")
+    major, minor, patch, channel, sequence = match.groups()
+    stable_tag = format_tag((int(major), int(minor), int(patch)))
+    return {
+        "tag": tag,
+        "stableTag": stable_tag,
+        "channel": channel.lower(),
+        "sequence": int(sequence) if sequence else 0,
+    }
 
 
 def strip_conventional(subject: str) -> tuple[str, str]:
@@ -170,9 +207,25 @@ def get_last_release(repo_root: str) -> ReleaseInfo | None:
     )
     for release in releases or []:
         tag = release.get("tagName")
-        if tag and SEMVER_TAG_RE.match(tag):
+        if tag and STABLE_TAG_RE.match(tag):
             return ReleaseInfo(tag=tag, name=release.get("name"), published_at=release.get("publishedAt"))
     return None
+
+
+def get_latest_prerelease_number(repo_root: str, stable_tag: str, channel: str) -> int:
+    output = git("tag", "--list", f"{stable_tag}-{channel}*", cwd=repo_root)
+    numbers = [0]
+    for raw_tag in output.splitlines():
+        tag = raw_tag.strip()
+        if not tag:
+            continue
+        try:
+            parsed = parse_prerelease_tag(tag)
+        except ValueError:
+            continue
+        if parsed["stableTag"] == stable_tag and parsed["channel"] == channel:
+            numbers.append(parsed["sequence"])
+    return max(numbers)
 
 
 def get_commit_files(repo_root: str, sha: str) -> list[str]:
@@ -230,7 +283,7 @@ def get_associated_pr(repo_root: str, repo_name: str, sha: str) -> dict[str, Any
     }
 
 
-def suggest_version(last_release: ReleaseInfo | None, meaningful_commits: list[dict[str, Any]]) -> dict[str, Any]:
+def suggest_stable_version(last_release: ReleaseInfo | None, meaningful_commits: list[dict[str, Any]]) -> dict[str, Any]:
     if last_release is None:
         return {
             "tag": "v0.1.0",
@@ -238,6 +291,8 @@ def suggest_version(last_release: ReleaseInfo | None, meaningful_commits: list[d
             "reason": "No published semver release was found, so start at v0.1.0.",
             "minorAlternative": None,
             "patchAlternative": None,
+            "releaseChannel": "stable",
+            "stableBaseTag": "v0.1.0",
         }
 
     major, minor, patch = parse_semver(last_release.tag)
@@ -268,6 +323,8 @@ def suggest_version(last_release: ReleaseInfo | None, meaningful_commits: list[d
             "reason": reason,
             "minorAlternative": minor_tag,
             "patchAlternative": None,
+            "releaseChannel": "stable",
+            "stableBaseTag": patch_tag,
         }
 
     reason = (
@@ -284,6 +341,60 @@ def suggest_version(last_release: ReleaseInfo | None, meaningful_commits: list[d
         "reason": reason,
         "minorAlternative": None,
         "patchAlternative": patch_tag,
+        "releaseChannel": "stable",
+        "stableBaseTag": minor_tag,
+    }
+
+
+def suggest_version(
+    repo_root: str,
+    last_release: ReleaseInfo | None,
+    meaningful_commits: list[dict[str, Any]],
+    channel: str,
+    promote_from: str | None,
+) -> dict[str, Any]:
+    stable_suggestion = suggest_stable_version(last_release, meaningful_commits)
+    if promote_from:
+        prerelease = parse_prerelease_tag(promote_from)
+        return {
+            "tag": prerelease["stableTag"],
+            "kind": "promotion",
+            "reason": f"Promote {promote_from} to stable {prerelease['stableTag']} from the same prerelease code base.",
+            "minorAlternative": None,
+            "patchAlternative": None,
+            "releaseChannel": "stable",
+            "stableBaseTag": prerelease["stableTag"],
+            "promotionSourceTag": promote_from,
+            "promotionChannel": prerelease["channel"],
+        }
+
+    if channel == "stable":
+        return stable_suggestion
+
+    stable_tag = stable_suggestion["tag"]
+    last_number = get_latest_prerelease_number(repo_root, stable_tag, channel)
+    prerelease_number = last_number + 1
+    prerelease_tag = f"{stable_tag}-{channel}.{prerelease_number}"
+    if last_number == 0:
+        reason = (
+            f"{channel} prerelease suggested from upcoming stable {stable_tag}. "
+            f"This will publish on the npm {channel} dist-tag instead of latest."
+        )
+    else:
+        reason = (
+            f"{channel} prerelease suggested from upcoming stable {stable_tag}. "
+            f"Found existing {channel} prereleases up to .{last_number}, so the next tag is {prerelease_tag}."
+        )
+    return {
+        "tag": prerelease_tag,
+        "kind": channel,
+        "reason": reason,
+        "minorAlternative": stable_suggestion.get("minorAlternative"),
+        "patchAlternative": stable_suggestion.get("patchAlternative"),
+        "releaseChannel": channel,
+        "stableBaseTag": stable_tag,
+        "promotionSourceTag": None,
+        "promotionChannel": None,
     }
 
 
@@ -352,24 +463,32 @@ def build_release_items(repo_root: str, repo_name: str, commits: list[dict[str, 
 def render_markdown(plan: dict[str, Any]) -> str:
     lines: list[str] = []
     repo = plan["repository"]["nameWithOwner"]
+    suggested_version = plan["suggestedVersion"]
     lines.append("# Release Plan")
     lines.append("")
     lines.append(f"- Repo: `{repo}`")
     lines.append(f"- Default branch: `{plan['repository']['defaultBranch']}`")
-    lines.append(f"- Planned branch tip: `{plan['planning']['baseSha']}`")
+    lines.append(f"- Planned source ref: `{plan['planning']['baseRef']}`")
+    lines.append(f"- Planned source SHA: `{plan['planning']['baseSha']}`")
     lines.append(f"- Current branch: `{plan['workingTree']['currentBranch']}`")
     lines.append(f"- Clean working tree: `{str(plan['workingTree']['isClean']).lower()}`")
+    lines.append(f"- Release channel: `{suggested_version['releaseChannel']}`")
+    lines.append(f"- Stable base tag: `{suggested_version['stableBaseTag']}`")
+    if suggested_version.get("promotionSourceTag"):
+        lines.append(f"- Promotion source tag: `{suggested_version['promotionSourceTag']}`")
 
     last_release = plan.get("lastRelease")
     if last_release:
-      lines.append(f"- Last release: `{last_release['tag']}` published `{last_release.get('publishedAt') or 'unknown'}`")
+        lines.append(f"- Last release: `{last_release['tag']}` published `{last_release.get('publishedAt') or 'unknown'}`")
     else:
-      lines.append("- Last release: none found")
+        lines.append("- Last release: none found")
 
     lines.append(f"- Commits on main since last release: `{plan['counts']['rawCommitCount']}`")
     lines.append(f"- Meaningful commits after filtering housekeeping: `{plan['counts']['meaningfulCommitCount']}`")
-    lines.append(f"- Suggested tag: `{plan['suggestedVersion']['tag']}` ({plan['suggestedVersion']['kind']})")
-    lines.append(f"- Version rationale: {plan['suggestedVersion']['reason']}")
+    lines.append(f"- Suggested tag: `{suggested_version['tag']}` ({suggested_version['kind']})")
+    lines.append(f"- Version rationale: {suggested_version['reason']}")
+    if suggested_version["releaseChannel"] != "stable":
+        lines.append(f"- npm dist-tag on publish: `{suggested_version['releaseChannel']}`")
     if plan["warnings"]:
         lines.append("")
         lines.append("## Warnings")
@@ -410,7 +529,17 @@ def render_markdown(plan: dict[str, Any]) -> str:
 
     lines.append("## Changelog Heading")
     lines.append("")
-    lines.append(f"Use this heading in `CHANGELOG.md`: `## {plan['suggestedVersion']['tag']} - {plan['generatedAtDate']}`")
+    lines.append(f"Use this heading in `CHANGELOG.md`: `## {suggested_version['tag']} - {plan['generatedAtDate']}`")
+    if suggested_version["releaseChannel"] != "stable":
+        lines.append("")
+        lines.append(
+            "For prereleases, prefer keeping the prerelease notes in the GitHub release and leave `CHANGELOG.md` for the eventual stable promotion unless the user explicitly wants prerelease entries there."
+        )
+    if suggested_version.get("promotionSourceTag"):
+        lines.append("")
+        lines.append(
+            "Promotion note: tag the same prerelease commit for exact code parity, or add only changelog/release-note edits on top before creating the stable tag."
+        )
     lines.append("")
     lines.append("Do not copy the raw titles verbatim into the release notes; rewrite them.")
     return "\n".join(lines).rstrip() + "\n"
@@ -420,6 +549,11 @@ def main() -> int:
     args = parse_args()
     repo_root = git("rev-parse", "--show-toplevel", cwd=os.getcwd())
     output_dir = Path(repo_root) / args.output_dir
+    channel = normalize_channel(args.channel)
+    if args.promote_from and channel != "stable":
+        raise RuntimeError("--promote-from can only be used with --channel stable.")
+    if args.promote_from:
+        parse_prerelease_tag(args.promote_from)
     try:
         output_dir_rel = output_dir.relative_to(Path(repo_root)).as_posix()
     except ValueError:
@@ -428,11 +562,17 @@ def main() -> int:
     repo_name = repo_info["nameWithOwner"]
     default_branch = repo_info["defaultBranchRef"]["name"]
     remote_ref = f"refs/remotes/origin/{default_branch}"
+    planning_ref = remote_ref
 
-    try:
-        base_sha = git("rev-parse", remote_ref, cwd=repo_root)
-    except RuntimeError:
-        base_sha = git("rev-parse", default_branch, cwd=repo_root)
+    if args.promote_from:
+        base_sha = git("rev-list", "-n", "1", args.promote_from, cwd=repo_root)
+        planning_ref = f"refs/tags/{args.promote_from}"
+    else:
+        try:
+            base_sha = git("rev-parse", remote_ref, cwd=repo_root)
+        except RuntimeError:
+            base_sha = git("rev-parse", default_branch, cwd=repo_root)
+            planning_ref = default_branch
 
     current_branch = git("branch", "--show-current", cwd=repo_root) or "(detached HEAD)"
     working_tree_status = git("status", "--porcelain", "--untracked-files=all", cwd=repo_root)
@@ -460,14 +600,18 @@ def main() -> int:
             meaningful_commits.append(commit)
 
     items = build_release_items(repo_root, repo_name, meaningful_commits)
-    suggested_version = suggest_version(last_release, meaningful_commits)
+    suggested_version = suggest_version(repo_root, last_release, meaningful_commits, channel, args.promote_from)
 
     warnings: list[str] = []
     if not is_clean:
         warnings.append("Working tree is not clean; pause before editing or releasing.")
     if current_branch != default_branch:
         warnings.append(f"Current branch is {current_branch}, not the default branch {default_branch}.")
-    if local_head != base_sha:
+    if args.promote_from and local_head != base_sha:
+        warnings.append(
+            f"Local HEAD {local_head[:7]} does not match promotion source {args.promote_from} {base_sha[:7]}; check out the prerelease commit or keep follow-up edits changelog-only before tagging stable."
+        )
+    if not args.promote_from and local_head != base_sha:
         warnings.append(
             f"Local HEAD {local_head[:7]} does not match origin/{default_branch} {base_sha[:7]}; fast-forward before releasing."
         )
@@ -487,7 +631,7 @@ def main() -> int:
             "defaultBranch": default_branch,
         },
         "planning": {
-            "baseRef": remote_ref,
+            "baseRef": planning_ref,
             "baseSha": base_sha,
             "range": commit_range,
         },

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag in the form vX.Y.Z
+        description: Release tag in the form vX.Y.Z or vX.Y.Z-beta.N
         required: true
         type: string
 
@@ -28,6 +28,21 @@ jobs:
       - name: Install Node.js and dependencies
         uses: ./.github/actions/configure-nodejs
 
+      - name: Resolve release metadata
+        id: release_meta
+        run: pnpm release:metadata "$RELEASE_TAG"
+
+      - name: Validate GitHub prerelease flag
+        if: ${{ github.event_name == 'release' }}
+        env:
+          EXPECTED_PRERELEASE: ${{ steps.release_meta.outputs.is_prerelease }}
+          ACTUAL_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [ "$EXPECTED_PRERELEASE" != "$ACTUAL_PRERELEASE" ]; then
+            echo "Release tag prerelease state ($EXPECTED_PRERELEASE) does not match GitHub release.prerelease ($ACTUAL_PRERELEASE)." >&2
+            exit 1
+          fi
+
       - name: Apply release version from tag
         run: pnpm release:apply-version "$RELEASE_TAG"
 
@@ -48,4 +63,6 @@ jobs:
           EOF
 
       - name: Publish openclaw-codex-app-server
-        run: pnpm publish --no-git-checks --access public
+        env:
+          NPM_DIST_TAG: ${{ steps.release_meta.outputs.npm_dist_tag }}
+        run: pnpm publish --no-git-checks --access public --tag "$NPM_DIST_TAG"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ openclaw plugins uninstall openclaw-codex-app-server
 
 OpenClaw `main` included the required plugin interface changes as of `2026-03-16`. Use any OpenClaw release that includes those changes, or use the local developer workflow at the bottom of this document.
 
+Pre-release packages are published on matching npm dist-tags instead of `latest`. For example, a tag such as `v0.3.0-beta.1` publishes to `openclaw-codex-app-server@beta`, so `npm install openclaw-codex-app-server@latest` stays on the newest stable release.
+
 ## Why Try It
 
 - Uses your existing local Codex CLI setup instead of a separate hosted bridge.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "pack:smoke": "node ./scripts/pack-smoke.mjs",
+    "release:metadata": "node ./scripts/release-metadata.mjs",
     "release:apply-version": "node ./scripts/apply-release-version.mjs"
   },
   "peerDependencies": {

--- a/scripts/apply-release-version.mjs
+++ b/scripts/apply-release-version.mjs
@@ -1,9 +1,10 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseReleaseTag } from "./release-tag.mjs";
 
 const workspaceRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const version = parseReleaseVersion(process.argv[2]);
+const version = parseReleaseTag(process.argv[2]).version;
 
 const packageJsonPath = path.join(workspaceRoot, "package.json");
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
@@ -22,14 +23,3 @@ if (updatedClientSource === clientSource) {
 }
 writeFileSync(clientPath, updatedClientSource);
 process.stdout.write(`updated src/client.ts -> ${version}\n`);
-
-function parseReleaseVersion(tagName) {
-  if (!tagName) {
-    throw new Error("Missing release tag. Expected vX.Y.Z");
-  }
-  const match = tagName.trim().match(/^v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/);
-  if (!match) {
-    throw new Error(`Invalid release tag: ${tagName}. Expected vX.Y.Z`);
-  }
-  return match[1];
-}

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -1,0 +1,17 @@
+import { appendFileSync } from "node:fs";
+import { parseReleaseTag } from "./release-tag.mjs";
+
+const metadata = parseReleaseTag(process.argv[2]);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendGitHubOutput("version", metadata.version);
+  appendGitHubOutput("is_prerelease", String(metadata.isPrerelease));
+  appendGitHubOutput("release_channel", metadata.channel ?? "stable");
+  appendGitHubOutput("npm_dist_tag", metadata.npmDistTag);
+}
+
+process.stdout.write(`${JSON.stringify(metadata, null, 2)}\n`);
+
+function appendGitHubOutput(name, value) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}

--- a/scripts/release-tag.mjs
+++ b/scripts/release-tag.mjs
@@ -1,0 +1,33 @@
+const RELEASE_TAG_RE =
+  /^v(?<version>\d+\.\d+\.\d+(?:-(?<prerelease>[0-9A-Za-z.-]+))?(?:\+(?<build>[0-9A-Za-z.-]+))?)$/;
+const CHANNEL_RE = /^[A-Za-z][0-9A-Za-z-]*$/;
+
+export function parseReleaseTag(tagName) {
+  if (!tagName) {
+    throw new Error("Missing release tag. Expected vX.Y.Z or vX.Y.Z-beta.N");
+  }
+
+  const match = tagName.trim().match(RELEASE_TAG_RE);
+  if (!match?.groups?.version) {
+    throw new Error(`Invalid release tag: ${tagName}. Expected vX.Y.Z or vX.Y.Z-beta.N`);
+  }
+
+  const prerelease = match.groups.prerelease ?? null;
+  const firstIdentifier = prerelease ? prerelease.split(".")[0] : null;
+  const channel = firstIdentifier ? firstIdentifier.toLowerCase() : null;
+
+  if (channel && !CHANNEL_RE.test(channel)) {
+    throw new Error(
+      `Invalid prerelease channel in tag ${tagName}: ${firstIdentifier}. Expected a leading alphabetic identifier like beta or rc.`,
+    );
+  }
+
+  return {
+    tagName: tagName.trim(),
+    version: match.groups.version,
+    prerelease,
+    isPrerelease: prerelease !== null,
+    channel,
+    npmDistTag: channel ?? "latest",
+  };
+}


### PR DESCRIPTION
## Summary
- route prerelease tags like `vX.Y.Z-beta.N` to matching npm dist-tags instead of `latest`
- extend the release planner and skill docs for stable, prerelease, and prerelease-promotion flows
- validate that GitHub prerelease state matches the release tag shape and document the install behavior

## Validation
- `pnpm test`
- `pnpm typecheck`
- `node ./scripts/release-metadata.mjs v0.3.0-beta.1`
- `python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release-stable-check`
- `python3 .agents/skills/release/scripts/release_plan.py --channel beta --output-dir .local/release-beta-check`
- `python3 .agents/skills/release/scripts/release_plan.py --promote-from v999.999.999-beta.1 --output-dir .local/release-promote-check`