### PR TITLE
Plugin: add project manager skill

### DIFF
--- a/.agents/skills/project-manager/SKILL.md
+++ b/.agents/skills/project-manager/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: project-manager
+description: "Manage GitHub issues and the GitHub Project board for this repository, while keeping the local tracker in sync. Use when the user wants to capture freeform requirements as issues, flesh out issue descriptions from repo or upstream research, triage Priority/Size/Workflow/Status, add issues or PRs to project 7, or reconcile GitHub state with `.local/work-items.yaml`."
+---
+
+# Project Manager
+
+Use this skill for repo-specific project management on [OpenClaw Codex App Server Project](https://github.com/orgs/pwrdrvr/projects/7).
+
+## Automation Preference
+
+- Prefer Node scripts for repo-local automation.
+- If a script needs dependencies, add them as repo `devDependencies` and invoke them through `pnpm` or `node`.
+- Avoid Python for repo-local skill automation unless a Python-native library is clearly worth the extra runtime dependency.
+
+## Canonical Locations
+
+- Treat GitHub Issues and PRs as the public source of truth.
+- Treat `.local/work-items.yaml` as a derived repo-local cross-reference map that can be regenerated from the project board.
+- Put temporary issue writeups only in `.local/issue-drafts/`.
+- Do not create parallel scratch directories or alternate tracker files for the same purpose.
+
+Current repo-specific locations:
+
+- Project board: `https://github.com/orgs/pwrdrvr/projects/7`
+- Local tracker: `.local/work-items.yaml`
+- Issue drafts: `.local/issue-drafts/`
+- Local id prefix: `ocas-`
+
+Refresh the derived tracker with:
+
+```bash
+pnpm project:sync
+```
+
+## Workflow
+
+1. Explore before filing.
+
+- Read local code, tests, docs, and upstream references before creating or expanding an issue.
+- Prefer issue bodies with concrete findings, source pointers, and proposed scope over vague placeholders.
+
+2. Draft locally when the issue is non-trivial.
+
+- Write or refresh the issue body in `.local/issue-drafts/<nn>-<slug>.md`.
+- Reuse that file for edits; do not fork the same issue into multiple local scratch notes.
+
+3. Create or update the GitHub issue.
+
+- Use `gh issue create`, `gh issue edit`, and `gh issue comment`.
+- Keep titles short and imperative, usually starting with `Plugin:`.
+
+4. Add the issue or PR to project `7`.
+
+- Use `gh project item-add 7 --owner pwrdrvr --url <issue-or-pr-url>`.
+- Set `Status`, `Priority`, `Size`, and `Workflow`.
+
+5. Sync `.local/work-items.yaml`.
+
+- Add or update the item entry with issue number, URLs, project item id, workflow, status, priority, size, and concise notes.
+- Update `last_synced_at` whenever the tracker changes.
+- Prefer pushing durable notes into GitHub issues or `.local/issue-drafts/`; the tracker should stay compact.
+
+6. Reconcile if anything drifted.
+
+- Use `gh issue list`, `gh project item-list`, and `gh project field-list` to confirm GitHub matches the local tracker.
+
+## Field Conventions
+
+- `Status`: `Inbox`, `Ready`, `In Progress`, `In Review`, `Done`
+- `Workflow`: `Plan`, `Review`, `Threads`, `Worktrees`, `Branches`
+
+Triage heuristic for this repo:
+
+- `P0`: quick wins that shrink the board fast, plus high-visibility completeness or pizazz work
+- `P1`: larger user-visible completeness work
+- `P2`: infrastructure, refactors, planning spikes, and corner-case cleanup unless they are very quick
+
+Size heuristic:
+
+- `XS` or `S`: obvious quick wins
+- `M`: bounded feature or bug fix with a few moving parts
+- `L`: visible feature touching multiple flows
+- `XL`: large architectural or cross-cutting work
+
+## Command Pattern
+
+Start by discovering current project field ids instead of assuming they never change:
+
+```bash
+gh project field-list 7 --owner pwrdrvr --format json
+```
+
+Typical flow:
+
+```bash
+gh issue create --repo pwrdrvr/openclaw-codex-app-server --title "<title>" --body-file .local/issue-drafts/<file>.md
+gh project item-add 7 --owner pwrdrvr --url <issue-or-pr-url> --format json
+gh project item-edit --project-id <project-id> --id <item-id> --field-id <field-id> --single-select-option-id <option-id>
+gh project item-list 7 --owner pwrdrvr --format json
+```
+
+Refresh the local tracker:
+
+```bash
+pnpm project:sync
+```
+
+## Tracker Shape
+
+Each `.local/work-items.yaml` item should keep:
+
+- `local_id`
+- `title`
+- `repo`
+- `source_note`
+- `github.issue_number`
+- `github.issue_url`
+- `github.project_number`
+- `github.project_url`
+- `github.project_item_id`
+- `state.issue_state`
+- `state.project_status`
+- `state.workflow`
+- `state.priority`
+- `state.size`
+- optional branch / PR fields
+- concise `notes`
+
+Keep notes factual and short. Store raw findings and writeups in the issue draft file or GitHub issue, not as sprawling tracker prose.

--- a/.agents/skills/project-manager/agents/openai.yaml
+++ b/.agents/skills/project-manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Project Manager"
+  short_description: "Manage issues, board, and local tracker"
+  default_prompt: "Use $project-manager to capture requirements into GitHub issues, keep project 7 in sync, and update the local .local tracker for this repo."

--- a/.agents/skills/project-manager/scripts/sync-work-items.mjs
+++ b/.agents/skills/project-manager/scripts/sync-work-items.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+const REPO = "pwrdrvr/openclaw-codex-app-server";
+const PROJECT_OWNER = "pwrdrvr";
+const PROJECT_NUMBER = 7;
+const PROJECT_URL = "https://github.com/orgs/pwrdrvr/projects/7";
+const TRACKER_PATH = path.resolve(".local/work-items.yaml");
+
+function runGh(args) {
+  return execFileSync("gh", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function loadExistingTracker() {
+  if (!fs.existsSync(TRACKER_PATH)) {
+    return { version: 1, last_synced_at: null, items: [] };
+  }
+
+  const raw = fs.readFileSync(TRACKER_PATH, "utf8");
+  const parsed = YAML.parse(raw) ?? {};
+  return {
+    version: parsed.version ?? 1,
+    last_synced_at: parsed.last_synced_at ?? null,
+    items: Array.isArray(parsed.items) ? parsed.items : [],
+  };
+}
+
+function normalizeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function nextLocalId(existingItems) {
+  let max = 0;
+  for (const item of existingItems) {
+    const match =
+      typeof item?.local_id === "string" ? item.local_id.match(/^ocas-(\d{4,})$/) : null;
+    if (match) {
+      max = Math.max(max, Number(match[1]));
+    }
+  }
+  return `ocas-${String(max + 1).padStart(4, "0")}`;
+}
+
+function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId) {
+  const current = existingByIssue.get(issueNumber);
+  if (current && typeof current === "object" && current !== null) {
+    return structuredClone(current);
+  }
+  return {
+    local_id: fallbackLocalId,
+    title: "",
+    repo: REPO,
+    source_note: "",
+    github: {},
+    state: {},
+    notes: [],
+  };
+}
+
+function main() {
+  const existing = loadExistingTracker();
+  const existingByIssue = new Map();
+  for (const item of existing.items) {
+    const issueNumber = normalizeNumber(item?.github?.issue_number);
+    if (issueNumber > 0) {
+      existingByIssue.set(issueNumber, item);
+    }
+  }
+
+  const issueList = JSON.parse(
+    runGh(["issue", "list", "--repo", REPO, "--state", "all", "--limit", "500", "--json", "number,state,title,url"]),
+  );
+  const issueByNumber = new Map(issueList.map((issue) => [issue.number, issue]));
+
+  const projectData = JSON.parse(
+    runGh(["project", "item-list", String(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--format", "json"]),
+  );
+
+  const items = [];
+  for (const item of projectData.items ?? []) {
+    const content = item?.content ?? {};
+    if (content.type !== "Issue") {
+      continue;
+    }
+    if (content.repository !== REPO) {
+      continue;
+    }
+    const issueNumber = normalizeNumber(content.number);
+    if (issueNumber <= 0) {
+      continue;
+    }
+
+    const issue = issueByNumber.get(issueNumber);
+    const merged = mergeExistingItem(existingByIssue, issueNumber, nextLocalId(existing.items));
+    merged.title = content.title ?? issue?.title ?? merged.title ?? "";
+    merged.repo = REPO;
+    merged.source_note = typeof merged.source_note === "string" ? merged.source_note : "";
+    if (typeof merged.raw_example !== "string") {
+      delete merged.raw_example;
+    }
+    merged.github = {
+      ...(merged.github && typeof merged.github === "object" ? merged.github : {}),
+      issue_number: issueNumber,
+      issue_url: content.url ?? issue?.url ?? "",
+      project_number: PROJECT_NUMBER,
+      project_url: PROJECT_URL,
+      project_item_id: item.id ?? "",
+    };
+    merged.state = {
+      ...(merged.state && typeof merged.state === "object" ? merged.state : {}),
+      issue_state: issue?.state ?? "OPEN",
+      project_status: item.status ?? "",
+      workflow: item.workflow ?? "",
+      priority: item.priority ?? "",
+      size: item.size ?? "",
+      branch: typeof merged.state?.branch === "string" ? merged.state.branch : "",
+      pr_number: normalizeNumber(merged.state?.pr_number),
+      pr_url: typeof merged.state?.pr_url === "string" ? merged.state.pr_url : "",
+    };
+    if (!Array.isArray(merged.notes)) {
+      merged.notes = [];
+    }
+    items.push(merged);
+  }
+
+  items.sort((a, b) => normalizeNumber(a.github?.issue_number) - normalizeNumber(b.github?.issue_number));
+
+  const usedIds = new Set();
+  let counter = 1;
+  for (const item of items) {
+    if (typeof item.local_id !== "string" || usedIds.has(item.local_id)) {
+      while (usedIds.has(`ocas-${String(counter).padStart(4, "0")}`)) {
+        counter += 1;
+      }
+      item.local_id = `ocas-${String(counter).padStart(4, "0")}`;
+      counter += 1;
+    }
+    usedIds.add(item.local_id);
+  }
+
+  const output = {
+    version: 1,
+    last_synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    items,
+  };
+
+  fs.mkdirSync(path.dirname(TRACKER_PATH), { recursive: true });
+  fs.writeFileSync(TRACKER_PATH, YAML.stringify(output, { lineWidth: 0 }), "utf8");
+  process.stdout.write(`Synced ${items.length} items to ${TRACKER_PATH}\n`);
+}
+
+main();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,14 @@
 
 Design notes and upstream behavior captures live under [`docs/specs/`](./docs/specs). Before changing approval, trust, sandbox, file-edit, or media-handling behavior, review [`docs/specs/PERMISSIONS.md`](./docs/specs/PERMISSIONS.md) and [`docs/specs/MEDIA.md`](./docs/specs/MEDIA.md).
 
+## Project Management
+Use the repo-local [`project-manager`](./.agents/skills/project-manager/SKILL.md) skill for GitHub issue and project-board work in this repository.
+
+- Project board: <https://github.com/orgs/pwrdrvr/projects/7>
+- Canonical local tracker: `.local/work-items.yaml` (derived; refresh with `pnpm project:sync`)
+- Canonical local issue drafts: `.local/issue-drafts/`
+- Do not create parallel scratch trackers or alternate temp directories for issue workups.
+
 ## Build, Test, and Development Commands
 Use `pnpm` for local work.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     ]
   },
   "scripts": {
+    "project:sync": "node ./.agents/skills/project-manager/scripts/sync-work-items.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "pack:smoke": "node ./scripts/pack-smoke.mjs",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.2)
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
 packages:
 


### PR DESCRIPTION
## Summary
- add a repo-local `project-manager` skill for GitHub issues and project board workflows
- document the repo's project-management conventions in `AGENTS.md`
- add a Node-based `pnpm project:sync` script to regenerate `.local/work-items.yaml` from project 7

## Validation
- `pnpm project:sync`
- did not run `pnpm test`
- did not run `pnpm typecheck`
