### PR TITLE
Plugin: make project manager skill configurable

### DIFF
--- a/.agents/project-manager.config.json
+++ b/.agents/project-manager.config.json
@@ -1,0 +1,9 @@
+{
+  "repo": "pwrdrvr/openclaw-codex-app-server",
+  "projectOwner": "pwrdrvr",
+  "projectNumber": 7,
+  "projectUrl": "https://github.com/orgs/pwrdrvr/projects/7",
+  "trackerPath": ".local/work-items.yaml",
+  "issueDraftDir": ".local/issue-drafts",
+  "localIdPrefix": "ocas-"
+}

--- a/.agents/skills/project-manager/SKILL.md
+++ b/.agents/skills/project-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: project-manager
-description: "Manage GitHub issues and the GitHub Project board for this repository, while keeping the local tracker in sync. Use when the user wants to capture freeform requirements as issues, flesh out issue descriptions from repo or upstream research, triage Priority/Size/Workflow/Status, add issues or PRs to project 7, or reconcile GitHub state with `.local/work-items.yaml`."
+description: "Manage GitHub issues and the GitHub Project board for the current repository, while keeping the local tracker in sync. Use when the user wants to capture freeform requirements as issues, flesh out issue descriptions from repo or upstream research, triage Priority/Size/Workflow/Status, add issues or PRs to the repo's configured project board, or reconcile GitHub state with `.local/work-items.yaml`."
 ---
 
 # Project Manager
 
-Use this skill for repo-specific project management on [OpenClaw Codex App Server Project](https://github.com/orgs/pwrdrvr/projects/7).
+Use this skill for repo-local project management.
 
 ## Automation Preference
 
@@ -19,14 +19,21 @@ Use this skill for repo-specific project management on [OpenClaw Codex App Serve
 - Treat `.local/work-items.yaml` as a derived repo-local cross-reference map that can be regenerated from the project board.
 - Put temporary issue writeups only in `.local/issue-drafts/`.
 - Do not create parallel scratch directories or alternate tracker files for the same purpose.
+- Read repo-specific values from `.agents/project-manager.config.json` before taking action.
 
-Current repo-specific locations:
+Expected config shape:
 
-- Canonical repo: `pwrdrvr/openclaw-codex-app-server`
-- Project board: `https://github.com/orgs/pwrdrvr/projects/7`
-- Local tracker: `.local/work-items.yaml`
-- Issue drafts: `.local/issue-drafts/`
-- Local id prefix: `ocas-`
+```json
+{
+  "repo": "owner/repo",
+  "projectOwner": "owner",
+  "projectNumber": 7,
+  "projectUrl": "https://github.com/orgs/owner/projects/7",
+  "trackerPath": ".local/work-items.yaml",
+  "issueDraftDir": ".local/issue-drafts",
+  "localIdPrefix": "item-"
+}
+```
 
 Refresh the derived tracker with:
 
@@ -51,9 +58,10 @@ pnpm project:sync
 - Use `gh issue create`, `gh issue edit`, and `gh issue comment`.
 - Keep titles short and imperative, usually starting with `Plugin:`.
 
-4. Add the issue or PR to project `7`.
+4. Add the issue or PR to the configured project board.
 
-- Use `gh project item-add 7 --owner pwrdrvr --url <issue-or-pr-url>`.
+- Read the configured project number and owner from `.agents/project-manager.config.json`.
+- Use `gh project item-add <project-number> --owner <project-owner> --url <issue-or-pr-url>`.
 - For issues, set `Status`, `Priority`, `Size`, and `Workflow`.
 - For PRs, usually set `Status` and `Workflow`; `Priority` and `Size` are issue-planning fields unless there is a specific reason to set them on the PR item.
 
@@ -91,17 +99,17 @@ Start by discovering current project field ids instead of assuming they never ch
 
 ```bash
 gh repo view --json nameWithOwner,url
-gh project view 7 --owner pwrdrvr --format json
-gh project field-list 7 --owner pwrdrvr --format json
+gh project view <project-number> --owner <project-owner> --format json
+gh project field-list <project-number> --owner <project-owner> --format json
 ```
 
 Typical flow:
 
 ```bash
-gh issue create --repo pwrdrvr/openclaw-codex-app-server --title "<title>" --body-file .local/issue-drafts/<file>.md
-gh project item-add 7 --owner pwrdrvr --url <issue-or-pr-url> --format json
+gh issue create --repo <owner/repo> --title "<title>" --body-file .local/issue-drafts/<file>.md
+gh project item-add <project-number> --owner <project-owner> --url <issue-or-pr-url> --format json
 gh project item-edit --project-id <project-id> --id <item-id> --field-id <field-id> --single-select-option-id <option-id>
-gh project item-list 7 --owner pwrdrvr --format json
+gh project item-list <project-number> --owner <project-owner> --format json
 ```
 
 Refresh the local tracker:
@@ -112,10 +120,10 @@ pnpm project:sync
 
 ## Gotchas
 
-- Verify the repo slug before issue commands. The canonical repo is `pwrdrvr/openclaw-codex-app-server`; older shorthand like `pwrdrvr/openclaw-app-server` is wrong and will make `gh issue ...` fail.
+- Verify the repo slug before issue commands. Treat `.agents/project-manager.config.json` as canonical when it is present.
 - `gh project item-edit` needs opaque ids for the project, item, field, and single-select option. Always discover them with `gh project view ...` and `gh project field-list ...` instead of assuming cached ids still match.
 - GitHub Projects custom views are not well-supported by `gh` or GraphQL mutations. Reading views works, but creating/editing/copying views is still better done in the web UI or browser automation. `gh project copy` does not carry over custom views.
-- `.local/work-items.yaml` is currently issue-only. Add PRs to project `7`, but do not expect `pnpm project:sync` to mirror PR items into the local tracker.
+- `.local/work-items.yaml` is currently issue-only. Add PRs to the project board, but do not expect `pnpm project:sync` to mirror PR items into the local tracker.
 - `.local/issue-drafts/<nn>-<slug>.md` filenames are local scratch ids, not GitHub issue numbers. Keep them stable enough to reuse, but do not try to force them to match the eventual GitHub issue number.
 
 ## Tracker Shape

--- a/.agents/skills/project-manager/agents/openai.yaml
+++ b/.agents/skills/project-manager/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Manager"
   short_description: "Manage issues, board, and local tracker"
-  default_prompt: "Use $project-manager to capture requirements into GitHub issues, keep project 7 in sync, and update the local .local tracker for this repo."
+  default_prompt: "Use $project-manager to capture requirements into GitHub issues, keep the configured project board in sync, and update the local .local tracker for this repo."

--- a/.agents/skills/project-manager/scripts/sync-work-items.mjs
+++ b/.agents/skills/project-manager/scripts/sync-work-items.mjs
@@ -5,11 +5,9 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 
-const REPO = "pwrdrvr/openclaw-codex-app-server";
-const PROJECT_OWNER = "pwrdrvr";
-const PROJECT_NUMBER = 7;
-const PROJECT_URL = "https://github.com/orgs/pwrdrvr/projects/7";
-const TRACKER_PATH = path.resolve(".local/work-items.yaml");
+const CONFIG_PATH = path.resolve(".agents/project-manager.config.json");
+const DEFAULT_TRACKER_PATH = ".local/work-items.yaml";
+const DEFAULT_LOCAL_ID_PREFIX = "item-";
 
 function runGh(args) {
   return execFileSync("gh", args, {
@@ -19,12 +17,65 @@ function runGh(args) {
   });
 }
 
-function loadExistingTracker() {
-  if (!fs.existsSync(TRACKER_PATH)) {
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function resolveRepoFromGh() {
+  const repo = JSON.parse(runGh(["repo", "view", "--json", "nameWithOwner"]));
+  const nameWithOwner = repo?.nameWithOwner?.trim();
+  if (!nameWithOwner) {
+    throw new Error("Could not determine repo from gh repo view.");
+  }
+  return nameWithOwner;
+}
+
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    throw new Error(`Missing project manager config at ${CONFIG_PATH}`);
+  }
+  const raw = readJson(CONFIG_PATH);
+  const repo =
+    typeof raw.repo === "string" && raw.repo.trim() ? raw.repo.trim() : resolveRepoFromGh();
+  const projectOwner =
+    typeof raw.projectOwner === "string" && raw.projectOwner.trim()
+      ? raw.projectOwner.trim()
+      : repo.split("/")[0];
+  const projectNumber =
+    typeof raw.projectNumber === "number" && Number.isFinite(raw.projectNumber)
+      ? raw.projectNumber
+      : 0;
+  if (projectNumber <= 0) {
+    throw new Error(`Invalid projectNumber in ${CONFIG_PATH}`);
+  }
+  const trackerPath =
+    typeof raw.trackerPath === "string" && raw.trackerPath.trim()
+      ? path.resolve(raw.trackerPath.trim())
+      : path.resolve(DEFAULT_TRACKER_PATH);
+  const projectUrl =
+    typeof raw.projectUrl === "string" && raw.projectUrl.trim()
+      ? raw.projectUrl.trim()
+      : `https://github.com/orgs/${projectOwner}/projects/${projectNumber}`;
+  const localIdPrefix =
+    typeof raw.localIdPrefix === "string" && raw.localIdPrefix.trim()
+      ? raw.localIdPrefix.trim()
+      : DEFAULT_LOCAL_ID_PREFIX;
+  return {
+    repo,
+    projectOwner,
+    projectNumber,
+    projectUrl,
+    trackerPath,
+    localIdPrefix,
+  };
+}
+
+function loadExistingTracker(trackerPath) {
+  if (!fs.existsSync(trackerPath)) {
     return { version: 1, last_synced_at: null, items: [] };
   }
 
-  const raw = fs.readFileSync(TRACKER_PATH, "utf8");
+  const raw = fs.readFileSync(trackerPath, "utf8");
   const parsed = YAML.parse(raw) ?? {};
   return {
     version: parsed.version ?? 1,
@@ -37,19 +88,21 @@ function normalizeNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function nextLocalId(existingItems) {
+function nextLocalId(existingItems, localIdPrefix) {
   let max = 0;
   for (const item of existingItems) {
     const match =
-      typeof item?.local_id === "string" ? item.local_id.match(/^ocas-(\d{4,})$/) : null;
+      typeof item?.local_id === "string"
+        ? item.local_id.match(new RegExp(`^${localIdPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\d{4,})$`))
+        : null;
     if (match) {
       max = Math.max(max, Number(match[1]));
     }
   }
-  return `ocas-${String(max + 1).padStart(4, "0")}`;
+  return `${localIdPrefix}${String(max + 1).padStart(4, "0")}`;
 }
 
-function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId) {
+function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId, repo) {
   const current = existingByIssue.get(issueNumber);
   if (current && typeof current === "object" && current !== null) {
     return structuredClone(current);
@@ -57,7 +110,7 @@ function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId) {
   return {
     local_id: fallbackLocalId,
     title: "",
-    repo: REPO,
+    repo,
     source_note: "",
     github: {},
     state: {},
@@ -66,7 +119,8 @@ function mergeExistingItem(existingByIssue, issueNumber, fallbackLocalId) {
 }
 
 function main() {
-  const existing = loadExistingTracker();
+  const config = loadConfig();
+  const existing = loadExistingTracker(config.trackerPath);
   const existingByIssue = new Map();
   for (const item of existing.items) {
     const issueNumber = normalizeNumber(item?.github?.issue_number);
@@ -76,12 +130,31 @@ function main() {
   }
 
   const issueList = JSON.parse(
-    runGh(["issue", "list", "--repo", REPO, "--state", "all", "--limit", "500", "--json", "number,state,title,url"]),
+    runGh([
+      "issue",
+      "list",
+      "--repo",
+      config.repo,
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,state,title,url",
+    ]),
   );
   const issueByNumber = new Map(issueList.map((issue) => [issue.number, issue]));
 
   const projectData = JSON.parse(
-    runGh(["project", "item-list", String(PROJECT_NUMBER), "--owner", PROJECT_OWNER, "--format", "json"]),
+    runGh([
+      "project",
+      "item-list",
+      String(config.projectNumber),
+      "--owner",
+      config.projectOwner,
+      "--format",
+      "json",
+    ]),
   );
 
   const items = [];
@@ -90,7 +163,7 @@ function main() {
     if (content.type !== "Issue") {
       continue;
     }
-    if (content.repository !== REPO) {
+    if (content.repository !== config.repo) {
       continue;
     }
     const issueNumber = normalizeNumber(content.number);
@@ -99,9 +172,14 @@ function main() {
     }
 
     const issue = issueByNumber.get(issueNumber);
-    const merged = mergeExistingItem(existingByIssue, issueNumber, nextLocalId(existing.items));
+    const merged = mergeExistingItem(
+      existingByIssue,
+      issueNumber,
+      nextLocalId(existing.items, config.localIdPrefix),
+      config.repo,
+    );
     merged.title = content.title ?? issue?.title ?? merged.title ?? "";
-    merged.repo = REPO;
+    merged.repo = config.repo;
     merged.source_note = typeof merged.source_note === "string" ? merged.source_note : "";
     if (typeof merged.raw_example !== "string") {
       delete merged.raw_example;
@@ -110,8 +188,8 @@ function main() {
       ...(merged.github && typeof merged.github === "object" ? merged.github : {}),
       issue_number: issueNumber,
       issue_url: content.url ?? issue?.url ?? "",
-      project_number: PROJECT_NUMBER,
-      project_url: PROJECT_URL,
+      project_number: config.projectNumber,
+      project_url: config.projectUrl,
       project_item_id: item.id ?? "",
     };
     merged.state = {
@@ -137,10 +215,10 @@ function main() {
   let counter = 1;
   for (const item of items) {
     if (typeof item.local_id !== "string" || usedIds.has(item.local_id)) {
-      while (usedIds.has(`ocas-${String(counter).padStart(4, "0")}`)) {
+      while (usedIds.has(`${config.localIdPrefix}${String(counter).padStart(4, "0")}`)) {
         counter += 1;
       }
-      item.local_id = `ocas-${String(counter).padStart(4, "0")}`;
+      item.local_id = `${config.localIdPrefix}${String(counter).padStart(4, "0")}`;
       counter += 1;
     }
     usedIds.add(item.local_id);
@@ -152,9 +230,9 @@ function main() {
     items,
   };
 
-  fs.mkdirSync(path.dirname(TRACKER_PATH), { recursive: true });
-  fs.writeFileSync(TRACKER_PATH, YAML.stringify(output, { lineWidth: 0 }), "utf8");
-  process.stdout.write(`Synced ${items.length} items to ${TRACKER_PATH}\n`);
+  fs.mkdirSync(path.dirname(config.trackerPath), { recursive: true });
+  fs.writeFileSync(config.trackerPath, YAML.stringify(output, { lineWidth: 0 }), "utf8");
+  process.stdout.write(`Synced ${items.length} items to ${config.trackerPath}\n`);
 }
 
 main();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Design notes and upstream behavior captures live under [`docs/specs/`](./docs/sp
 ## Project Management
 Use the repo-local [`project-manager`](./.agents/skills/project-manager/SKILL.md) skill for GitHub issue and project-board work in this repository.
 
+- Repo/project config: `.agents/project-manager.config.json`
 - Project board: <https://github.com/orgs/pwrdrvr/projects/7>
 - Canonical local tracker: `.local/work-items.yaml` (derived; refresh with `pnpm project:sync`)
 - Canonical local issue drafts: `.local/issue-drafts/`


### PR DESCRIPTION
## Summary
- make the repo-local `project-manager` skill configurable via `.agents/project-manager.config.json`
- remove hardcoded repo and project values from the skill text, UI metadata, and sync script
- document the repo-local config file in `AGENTS.md`

## Validation
- `pnpm project:sync`
- did not run `pnpm test`
- did not run `pnpm typecheck`
