### PR TITLE
Discord: settle completed button interactions cleanly

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -628,6 +628,138 @@ describe("Discord controller flows", () => {
     expect(followUp).not.toHaveBeenCalled();
   });
 
+  it("does not send a second Discord response after completing a questionnaire", async () => {
+    const { controller } = await createControllerHarness();
+    await (controller as any).store.upsertPendingRequest({
+      requestId: "questionnaire-1",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      state: {
+        requestId: "questionnaire-1",
+        options: [],
+        expiresAt: Date.now() + 60_000,
+        questionnaire: {
+          currentIndex: 1,
+          awaitingFreeform: false,
+          questions: [
+            {
+              index: 0,
+              id: "milk",
+              header: "Milk",
+              prompt: "Do you like milk on cereal?",
+              options: [
+                { key: "A", label: "Yes", description: "Sure." },
+                { key: "B", label: "No", description: "Nope." },
+              ],
+            },
+            {
+              index: 1,
+              id: "type",
+              header: "Type",
+              prompt: "What kind of milk?",
+              options: [
+                { key: "A", label: "Whole", description: "Richer." },
+                { key: "B", label: "2%", description: "Lighter." },
+              ],
+            },
+          ],
+          answers: [
+            {
+              kind: "option",
+              optionKey: "A",
+              optionLabel: "Yes",
+            },
+            null,
+          ],
+        },
+      },
+      updatedAt: Date.now(),
+    });
+    const callback = await (controller as any).store.putCallback({
+      kind: "pending-questionnaire",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+      requestId: "questionnaire-1",
+      questionIndex: 1,
+      action: "select",
+      optionIndex: 0,
+    });
+    const acknowledge = vi.fn(async () => {});
+    const clearComponents = vi.fn(async () => {});
+    const reply = vi.fn(async () => {});
+    const followUp = vi.fn(async () => {});
+    const submitPendingInputPayload = vi.fn(async () => true);
+    (controller as any).activeRuns.set("discord::default::channel:chan-1::", {
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+      workspaceDir: "/repo/openclaw",
+      mode: "plan",
+      handle: {
+        result: Promise.resolve({ threadId: "thread-1", text: "done" }),
+        queueMessage: vi.fn(async () => false),
+        submitPendingInput: vi.fn(async () => false),
+        submitPendingInputPayload,
+        interrupt: vi.fn(async () => {}),
+        isAwaitingInput: vi.fn(() => true),
+        getThreadId: vi.fn(() => "thread-1"),
+      },
+    });
+
+    await controller.handleDiscordInteractive({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "interaction-1",
+      conversationId: "channel:chan-1",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "button",
+        data: `codexapp:${callback.token}`,
+        namespace: "codexapp",
+        payload: callback.token,
+        messageId: "message-1",
+      },
+      senderId: "user-1",
+      senderUsername: "Ada",
+      respond: {
+        acknowledge,
+        reply,
+        followUp,
+        editMessage: vi.fn(async () => {}),
+        clearComponents,
+      },
+    } as any);
+
+    expect(submitPendingInputPayload).toHaveBeenCalledWith({
+      answers: {
+        milk: { answers: ["Yes"] },
+        type: { answers: ["Whole"] },
+      },
+    });
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(clearComponents).not.toHaveBeenCalled();
+    expect(discordSdkState.editDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel:chan-1",
+      "message-1",
+      {
+        text: "Recorded your answers and sent them to Codex.",
+      },
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(reply).not.toHaveBeenCalled();
+    expect(followUp).not.toHaveBeenCalled();
+  });
+
   it("normalizes raw Discord callback conversation ids for guild interactions", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
     const callback = await (controller as any).store.putCallback({

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -855,25 +855,29 @@ export class CodexPluginController {
         conversation,
         clear: async () => {
           const messageId = ctx.interaction.messageId?.trim();
-          if (callback.kind === "pending-input" && messageId) {
+          if ((callback.kind === "pending-input" || callback.kind === "pending-questionnaire") && messageId) {
             await ctx.respond
               .acknowledge()
               .then(() => {
                 interactionSettled = true;
               })
               .catch(() => undefined);
+            const completionText =
+              callback.kind === "pending-questionnaire"
+                ? "Recorded your answers and sent them to Codex."
+                : "Sent to Codex.";
             await editDiscordComponentMessage(
               conversation.conversationId,
               messageId,
               {
-                text: "Sent to Codex.",
+                text: completionText,
               },
               {
                 accountId: conversation.accountId,
               },
             ).catch((error) => {
               this.api.logger.warn(
-                `codex discord pending-input clear failed conversation=${conversationId}: ${String(error)}`,
+                `codex discord ${callback.kind} clear failed conversation=${conversationId}: ${String(error)}`,
               );
             });
             return;
@@ -3001,7 +3005,9 @@ export class CodexPluginController {
         }
         await responders.clear().catch(() => undefined);
         await this.store.removePendingRequest(pending.requestId);
-        await responders.reply("Recorded your answers and sent them to Codex.");
+        if (callback.conversation.channel !== "discord") {
+          await responders.reply("Recorded your answers and sent them to Codex.");
+        }
         return;
       }
       await this.sendPendingQuestionnaire(callback.conversation, pending.state, {


### PR DESCRIPTION
## Summary
- I fixed Discord pending input and questionnaire buttons to acknowledge the interaction once and replace the original message with a completion state instead of leaving stale approval buttons behind.
- I tracked whether a Discord interaction was already settled so follow-up messages use `followUp` when needed and we stop trying to send a second ephemeral reply after the button click has already been acknowledged.
- I expanded the Discord controller coverage around pending-input, questionnaire completion, and plan follow-up behavior so the interaction lifecycle stays exercised in tests.

## Validation
- `pnpm test`
- `pnpm typecheck`
