### PR TITLE
Plugin: switch slash commands to /cas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# OpenClaw App Server Bridge
+# OpenClaw Plugin For Codex App Server
 
-Independent OpenClaw bridge for using Codex App Server from Telegram and Discord conversations. Bind a chat to a Codex thread, talk to it with plain text, and control it with chat-native commands for resume, planning, review, model selection, compaction, and more.
+This project has no product name. It is just an OpenClaw plugin that connects OpenClaw to the Codex App Server protocol so you can interact with your existing threads from Codex Desktop and Codex TUI through Telegram and Discord conversations.
 
-This repository is a simple bridge for using Codex through OpenClaw. It is not affiliated with or endorsed by OpenAI.
+`Codex` is mentioned here only to describe the protocol and toolchain this plugin connects to. This repository is independent and is not official, provided, sponsored, endorsed, or affiliated with OpenAI or Codex.
 
 If `codex` already works on the machine running OpenClaw, this plugin should work too. It uses the same local Codex CLI and shared login state. There is no separate plugin login requirement for normal use.
 
@@ -10,7 +10,7 @@ If `codex` already works on the machine running OpenClaw, this plugin should wor
 
 1. Install the plugin into OpenClaw.
 2. Start in the Telegram or Discord conversation where you want the bridge bound.
-3. Run `/codex_resume`.
+3. Run `/cas_resume`.
 4. Pick a project and thread, or search directly.
 5. Once bound, plain text in that conversation routes to the selected Codex thread.
 
@@ -39,58 +39,58 @@ Pre-release packages are published on matching npm dist-tags instead of `latest`
 ## Why Try It
 
 - Uses your existing local Codex CLI setup instead of a separate hosted bridge.
-- Feels natural in chat: bind once with `/codex_resume`, then just talk.
-- Keeps useful controls close at hand with `/codex_status`, `/codex_plan`, `/codex_review`, `/codex_model`, and more.
+- Feels natural in chat: bind once with `/cas_resume`, then just talk.
+- Keeps useful controls close at hand with `/cas_status`, `/cas_plan`, `/cas_review`, `/cas_model`, and more.
 - Works well for Telegram and Discord conversations that you want tied to a real Codex thread.
 
 ## Typical Workflow
 
-1. Run `/codex_resume` in the conversation you want to bind.
-2. Use the picker buttons, or pass a filter like `/codex_resume release-fix` or `/codex_resume --projects`.
+1. Run `/cas_resume` in the conversation you want to bind.
+2. Use the picker buttons, or pass a filter like `/cas_resume release-fix` or `/cas_resume --projects`.
 3. Send normal chat messages once the thread is bound.
-4. Use control commands such as `/codex_status`, `/codex_plan`, `/codex_review`, `/codex_model`, and `/codex_stop` as needed.
-5. If you leave plan mode through the normal `Implement this plan` button, you do not need `/codex_plan off`; use `/codex_plan off` only when you want to exit planning manually instead.
+4. Use control commands such as `/cas_status`, `/cas_plan`, `/cas_review`, `/cas_model`, and `/cas_stop` as needed.
+5. If you leave plan mode through the normal `Implement this plan` button, you do not need `/cas_plan off`; use `/cas_plan off` only when you want to exit planning manually instead.
 
 ## Command Reference
 
 | Command | What it does | Notes / examples |
 | --- | --- | --- |
-| `/codex_resume` | Bind this conversation to a Codex thread. | With no args, opens a picker for recent sessions in the current workspace. |
-| `/codex_resume --projects` | Browse projects first. | Opens a project picker, then a thread picker. |
-| `/codex_resume --all` | Search recent sessions across projects. | Useful when the thread is not in the current workspace. |
-| `/codex_resume --cwd ~/github/openclaw` | Restrict browsing/search to one workspace. | `--cwd` accepts an absolute path or `~/...`. |
-| `/codex_resume --sync` | Resume and try to sync the chat/topic name to the Codex thread. | You can combine this with other flags. |
-| `/codex_resume release-fix` | Resume a matching thread by title or id. | If more than one thread matches, you get buttons to choose. |
-| `/codex_status` | Show the current binding and thread state. | Includes thread id, model, workspace, sandbox, and permissions when available. |
-| `/codex_detach` | Unbind this conversation from Codex. | Stops routing plain text from this conversation into the bound thread. |
-| `/codex_stop` | Interrupt the active Codex run. | Only applies when a turn is currently in progress. |
-| `/codex_steer <message>` | Send follow-up steer text to an active run. | Example: `/codex_steer focus on the failing tests first` |
-| `/codex_plan <goal>` | Ask Codex to plan instead of execute. | The plugin relays plan questions and the final plan back into chat. |
-| `/codex_plan off` | Exit plan mode for this conversation. | Use this when you want to leave planning manually instead of through the normal `Implement this plan` button. |
-| `/codex_review` | Review the current uncommitted changes in the bound workspace. | Requires an existing binding. |
-| `/codex_review <focus>` | Review with custom instructions. | Example: `/codex_review focus on thread selection regressions` |
-| `/codex_compact` | Compact the bound Codex thread. | The plugin posts progress and final context usage. |
-| `/codex_skills` | List available Codex skills for the workspace. | Adds buttons for up to eight skill shortcuts. |
-| `/codex_skills review` | Filter the skills list. | Matches skill name, description, or cwd. |
-| `/codex_experimental` | List experimental features reported by Codex. | Read-only. |
-| `/codex_mcp` | List configured MCP servers. | Shows auth state and counts for tools/resources/templates. |
-| `/codex_mcp github` | Filter MCP servers. | Matches name and auth status. |
-| `/codex_fast` | Toggle fast mode for the bound thread. | Equivalent to switching the service tier between default and fast. |
-| `/codex_fast on|off|status` | Set or inspect fast mode explicitly. | Example: `/codex_fast status` |
-| `/codex_model` | List models and show model-selection buttons. | If the conversation is not bound yet, it lists models only. |
-| `/codex_model gpt-5.4` | Set the model for the bound thread. | Requires an existing binding. |
-| `/codex_permissions` | Show account, rate-limit, and thread permission information. | Works with or without a current binding. |
-| `/codex_init ...` | Forward `/init` to Codex. | Sends the alias straight through to the App Server. |
-| `/codex_diff ...` | Forward `/diff` to Codex. | Sends the alias straight through to the App Server. |
-| `/codex_rename <new name>` | Rename the bound Codex thread. | Example: `/codex_rename approval flow cleanup` |
-| `/codex_rename --sync <new name>` | Rename the thread and try to sync the conversation/topic name too. | Requires an existing binding. |
+| `/cas_resume` | Bind this conversation to a Codex thread. | With no args, opens a picker for recent sessions in the current workspace. |
+| `/cas_resume --projects` | Browse projects first. | Opens a project picker, then a thread picker. |
+| `/cas_resume --all` | Search recent sessions across projects. | Useful when the thread is not in the current workspace. |
+| `/cas_resume --cwd ~/github/openclaw` | Restrict browsing/search to one workspace. | `--cwd` accepts an absolute path or `~/...`. |
+| `/cas_resume --sync` | Resume and try to sync the chat/topic name to the Codex thread. | You can combine this with other flags. |
+| `/cas_resume release-fix` | Resume a matching thread by title or id. | If more than one thread matches, you get buttons to choose. |
+| `/cas_status` | Show the current binding and thread state. | Includes thread id, model, workspace, sandbox, and permissions when available. |
+| `/cas_detach` | Unbind this conversation from Codex. | Stops routing plain text from this conversation into the bound thread. |
+| `/cas_stop` | Interrupt the active Codex run. | Only applies when a turn is currently in progress. |
+| `/cas_steer <message>` | Send follow-up steer text to an active run. | Example: `/cas_steer focus on the failing tests first` |
+| `/cas_plan <goal>` | Ask Codex to plan instead of execute. | The plugin relays plan questions and the final plan back into chat. |
+| `/cas_plan off` | Exit plan mode for this conversation. | Use this when you want to leave planning manually instead of through the normal `Implement this plan` button. |
+| `/cas_review` | Review the current uncommitted changes in the bound workspace. | Requires an existing binding. |
+| `/cas_review <focus>` | Review with custom instructions. | Example: `/cas_review focus on thread selection regressions` |
+| `/cas_compact` | Compact the bound Codex thread. | The plugin posts progress and final context usage. |
+| `/cas_skills` | List available Codex skills for the workspace. | Adds buttons for up to eight skill shortcuts. |
+| `/cas_skills review` | Filter the skills list. | Matches skill name, description, or cwd. |
+| `/cas_experimental` | List experimental features reported by Codex. | Read-only. |
+| `/cas_mcp` | List configured MCP servers. | Shows auth state and counts for tools/resources/templates. |
+| `/cas_mcp github` | Filter MCP servers. | Matches name and auth status. |
+| `/cas_fast` | Toggle fast mode for the bound thread. | Equivalent to switching the service tier between default and fast. |
+| `/cas_fast on|off|status` | Set or inspect fast mode explicitly. | Example: `/cas_fast status` |
+| `/cas_model` | List models and show model-selection buttons. | If the conversation is not bound yet, it lists models only. |
+| `/cas_model gpt-5.4` | Set the model for the bound thread. | Requires an existing binding. |
+| `/cas_permissions` | Show account, rate-limit, and thread permission information. | Works with or without a current binding. |
+| `/cas_init ...` | Forward `/init` to Codex. | Sends the alias straight through to the App Server. |
+| `/cas_diff ...` | Forward `/diff` to Codex. | Sends the alias straight through to the App Server. |
+| `/cas_rename <new name>` | Rename the bound Codex thread. | Example: `/cas_rename approval flow cleanup` |
+| `/cas_rename --sync <new name>` | Rename the thread and try to sync the conversation/topic name too. | Requires an existing binding. |
 
 ## Screenshot Placeholders
 
-- `[TODO screenshot] /codex_resume --projects` project picker
-- `[TODO screenshot] /codex_resume` thread picker with buttons
-- `[TODO screenshot] bound conversation after /codex_status`
-- `[TODO screenshot] /codex_model` button list
+- `[TODO screenshot] /cas_resume --projects` project picker
+- `[TODO screenshot] /cas_resume` thread picker with buttons
+- `[TODO screenshot] bound conversation after /cas_status`
+- `[TODO screenshot] /cas_model` button list
 
 ## Plugin Config Notes
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -36,6 +36,25 @@ describe("plugin registration", () => {
     expect(api.on).toHaveBeenCalledWith("inbound_claim", expect.any(Function));
     expect(api.registerInteractiveHandler).toHaveBeenCalledTimes(2);
     expect(api.registerCommand).toHaveBeenCalled();
+    expect(api.registerCommand.mock.calls.map(([params]) => params.name)).toEqual([
+      "cas_resume",
+      "cas_detach",
+      "cas_status",
+      "cas_stop",
+      "cas_steer",
+      "cas_plan",
+      "cas_review",
+      "cas_compact",
+      "cas_skills",
+      "cas_experimental",
+      "cas_mcp",
+      "cas_fast",
+      "cas_model",
+      "cas_permissions",
+      "cas_init",
+      "cas_diff",
+      "cas_rename",
+    ]);
   });
 
   it("registers the binding resolved hook when available", () => {

--- a/index.ts
+++ b/index.ts
@@ -3,29 +3,29 @@ import { CodexPluginController } from "./src/controller.js";
 import { INTERACTIVE_NAMESPACE } from "./src/types.js";
 
 const COMMANDS = [
-  ["codex_resume", "Resume or bind an existing Codex thread."],
-  ["codex_detach", "Detach this conversation from the current Codex thread."],
-  ["codex_status", "Show the current Codex binding and thread state."],
-  ["codex_stop", "Stop the active Codex turn."],
-  ["codex_steer", "Send a steer message to the active Codex turn."],
-  ["codex_plan", "Ask Codex to produce a plan, or use 'off' to exit plan mode."],
-  ["codex_review", "Run Codex review on the current changes."],
-  ["codex_compact", "Compact the current Codex thread."],
-  ["codex_skills", "List Codex skills."],
-  ["codex_experimental", "List Codex experimental features."],
-  ["codex_mcp", "List Codex MCP servers."],
-  ["codex_fast", "Toggle Codex fast mode."],
-  ["codex_model", "List or switch the Codex model."],
-  ["codex_permissions", "Show Codex permissions and account status."],
-  ["codex_init", "Forward /init to Codex."],
-  ["codex_diff", "Forward /diff to Codex."],
-  ["codex_rename", "Rename the Codex thread and sync the channel name when possible."],
+  ["cas_resume", "Resume or bind an existing Codex thread."],
+  ["cas_detach", "Detach this conversation from the current Codex thread."],
+  ["cas_status", "Show the current Codex binding and thread state."],
+  ["cas_stop", "Stop the active Codex turn."],
+  ["cas_steer", "Send a steer message to the active Codex turn."],
+  ["cas_plan", "Ask Codex to produce a plan, or use 'off' to exit plan mode."],
+  ["cas_review", "Run Codex review on the current changes."],
+  ["cas_compact", "Compact the current Codex thread."],
+  ["cas_skills", "List Codex skills."],
+  ["cas_experimental", "List Codex experimental features."],
+  ["cas_mcp", "List Codex MCP servers."],
+  ["cas_fast", "Toggle Codex fast mode."],
+  ["cas_model", "List or switch the Codex model."],
+  ["cas_permissions", "Show Codex permissions and account status."],
+  ["cas_init", "Forward /init to Codex."],
+  ["cas_diff", "Forward /diff to Codex."],
+  ["cas_rename", "Rename the Codex thread and sync the channel name when possible."],
 ] as const;
 
 const plugin = {
   id: "openclaw-codex-app-server",
-  name: "OpenClaw App Server Bridge",
-  description: "Independent OpenClaw bridge for Codex App Server.",
+  name: "OpenClaw Plugin For Codex App Server",
+  description: "Independent OpenClaw plugin for the Codex App Server protocol.",
   register(api: OpenClawPluginApi) {
     const controller = new CodexPluginController(api);
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-codex-app-server",
-  "name": "OpenClaw App Server Bridge",
-  "description": "Independent OpenClaw bridge for Codex App Server with bound Telegram and Discord conversations.",
+  "name": "OpenClaw Plugin For Codex App Server",
+  "description": "Independent OpenClaw plugin for the Codex App Server protocol with bound Telegram and Discord conversations.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-codex-app-server",
   "version": "0.0.0",
-  "description": "Independent OpenClaw bridge for Codex App Server conversations",
+  "description": "Independent OpenClaw plugin for the Codex App Server protocol",
   "author": "PwrDrvr LLC",
   "license": "MIT",
   "packageManager": "pnpm@10.29.3",

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -199,7 +199,7 @@ function buildDiscordCommandContext(
     channelId: "discord",
     isAuthorizedSender: true,
     args: "",
-    commandBody: "/codex_resume",
+    commandBody: "/cas_resume",
     config: {},
     from: "discord:channel:chan-1",
     to: "slash:user-1",
@@ -220,7 +220,7 @@ function buildTelegramCommandContext(
     channelId: "telegram",
     isAuthorizedSender: true,
     args: "",
-    commandBody: "/codex_status",
+    commandBody: "/cas_status",
     config: {},
     from: "telegram:123",
     to: "telegram:123",
@@ -299,7 +299,7 @@ describe("Discord controller flows", () => {
   it("uses the real Discord conversation target for slash-command resume pickers", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
 
-    const reply = await controller.handleCommand("codex_resume", buildDiscordCommandContext());
+    const reply = await controller.handleCommand("cas_resume", buildDiscordCommandContext());
 
     expect(reply).toEqual({
       text: "Sent a Codex thread picker to this Discord conversation.",
@@ -329,8 +329,8 @@ describe("Discord controller flows", () => {
       updatedAt: Date.now(),
     });
 
-    const reply = await controller.handleCommand("codex_model", buildDiscordCommandContext({
-      commandBody: "/codex_model",
+    const reply = await controller.handleCommand("cas_model", buildDiscordCommandContext({
+      commandBody: "/cas_model",
       getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
     }));
 
@@ -349,8 +349,8 @@ describe("Discord controller flows", () => {
   it("sends Discord skills directly instead of returning Telegram buttons", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
 
-    const reply = await controller.handleCommand("codex_skills", buildDiscordCommandContext({
-      commandBody: "/codex_skills",
+    const reply = await controller.handleCommand("cas_skills", buildDiscordCommandContext({
+      commandBody: "/cas_skills",
     }));
 
     expect(reply).toEqual({
@@ -597,8 +597,8 @@ describe("Discord controller flows", () => {
       updatedAt: Date.now(),
     });
 
-    const reply = await controller.handleCommand("codex_status", buildDiscordCommandContext({
-      commandBody: "/codex_status",
+    const reply = await controller.handleCommand("cas_status", buildDiscordCommandContext({
+      commandBody: "/cas_status",
       getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
     }));
 
@@ -631,11 +631,11 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_status",
+      "cas_status",
       buildDiscordCommandContext({
         from: "discord:1177378744822943744",
         to: "slash:1177378744822943744",
-        commandBody: "/codex_status",
+        commandBody: "/cas_status",
         getCurrentConversationBinding: vi.fn(async () => null),
       }),
     );
@@ -660,9 +660,9 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_status",
+      "cas_status",
       buildTelegramCommandContext({
-        commandBody: "/codex_status",
+        commandBody: "/cas_status",
         getCurrentConversationBinding: vi.fn(async () => null),
       }),
     );
@@ -709,8 +709,8 @@ describe("Discord controller flows", () => {
       },
     });
 
-    const reply = await controller.handleCommand("codex_status", buildDiscordCommandContext({
-      commandBody: "/codex_status",
+    const reply = await controller.handleCommand("cas_status", buildDiscordCommandContext({
+      commandBody: "/cas_status",
       getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
     }));
 
@@ -739,10 +739,10 @@ describe("Discord controller flows", () => {
     }));
 
     const reply = await controller.handleCommand(
-      "codex_rename",
+      "cas_rename",
       buildTelegramCommandContext({
         args: "—sync New Topic Name",
-        commandBody: "/codex_rename —sync New Topic Name",
+        commandBody: "/cas_rename —sync New Topic Name",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
       }),
@@ -766,10 +766,10 @@ describe("Discord controller flows", () => {
     const { controller, renameTopic, sendMessageTelegram } = await createControllerHarness();
 
     const reply = await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "—sync thread-1",
-        commandBody: "/codex_resume —sync thread-1",
+        commandBody: "/cas_resume —sync thread-1",
         messageThreadId: 456,
       }),
     );
@@ -793,10 +793,10 @@ describe("Discord controller flows", () => {
     const fetchMock = vi.mocked(fetch);
 
     await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "thread-1",
-        commandBody: "/codex_resume thread-1",
+        commandBody: "/cas_resume thread-1",
         messageThreadId: 456,
       }),
     );
@@ -831,9 +831,9 @@ describe("Discord controller flows", () => {
     );
 
     await controller.handleCommand(
-      "codex_detach",
+      "cas_detach",
       buildTelegramCommandContext({
-        commandBody: "/codex_detach",
+        commandBody: "/cas_detach",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "binding-1" })),
       }),
@@ -853,10 +853,10 @@ describe("Discord controller flows", () => {
     vi.spyOn(controller as any, "resolveDiscordBotToken").mockResolvedValue("discord-token");
 
     await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildDiscordCommandContext({
         args: "thread-1",
-        commandBody: "/codex_resume thread-1",
+        commandBody: "/cas_resume thread-1",
       }),
     );
 
@@ -886,9 +886,9 @@ describe("Discord controller flows", () => {
     );
 
     await controller.handleCommand(
-      "codex_detach",
+      "cas_detach",
       buildDiscordCommandContext({
-        commandBody: "/codex_detach",
+        commandBody: "/cas_detach",
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "binding-1" })),
       }),
     );
@@ -918,10 +918,10 @@ describe("Discord controller flows", () => {
       });
 
     const pendingReply = await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "--sync thread-1",
-        commandBody: "/codex_resume --sync thread-1",
+        commandBody: "/cas_resume --sync thread-1",
         messageThreadId: 456,
         requestConversationBinding,
       }),
@@ -942,10 +942,10 @@ describe("Discord controller flows", () => {
     );
 
     const hydratedReply = await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "--sync",
-        commandBody: "/codex_resume --sync",
+        commandBody: "/cas_resume --sync",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
       }),
@@ -999,10 +999,10 @@ describe("Discord controller flows", () => {
     }));
 
     const reply = await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "--sync",
-        commandBody: "/codex_resume --sync",
+        commandBody: "/cas_resume --sync",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => null),
         requestConversationBinding,
@@ -1040,10 +1040,10 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_resume",
+      "cas_resume",
       buildTelegramCommandContext({
         args: "--sync",
-        commandBody: "/codex_resume --sync",
+        commandBody: "/cas_resume --sync",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => null),
         requestConversationBinding: vi.fn(async () => ({ status: "bound" as const })),
@@ -1386,10 +1386,10 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_rename",
+      "cas_rename",
       buildTelegramCommandContext({
         args: "--sync",
-        commandBody: "/codex_rename --sync",
+        commandBody: "/cas_rename --sync",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
       }),
@@ -1426,10 +1426,10 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_rename",
+      "cas_rename",
       buildTelegramCommandContext({
         args: "--sync",
-        commandBody: "/codex_rename --sync",
+        commandBody: "/cas_rename --sync",
         messageThreadId: 456,
         getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
       }),
@@ -1445,9 +1445,9 @@ describe("Discord controller flows", () => {
     const { controller } = await createControllerHarness();
     const requestConversationBinding = vi.fn(async () => ({ status: "bound" as const }));
 
-    await controller.handleCommand("codex_resume", buildDiscordCommandContext({
+    await controller.handleCommand("cas_resume", buildDiscordCommandContext({
       args: "thread-1",
-      commandBody: "/codex_resume thread-1",
+      commandBody: "/cas_resume thread-1",
       requestConversationBinding,
     }));
 
@@ -1805,10 +1805,10 @@ describe("Discord controller flows", () => {
     });
 
     const reply = await controller.handleCommand(
-      "codex_plan",
+      "cas_plan",
       buildDiscordCommandContext({
         args: "off",
-        commandBody: "/codex_plan off",
+        commandBody: "/cas_plan off",
       }),
     );
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -394,7 +394,13 @@ function parseFastAction(
   if (normalized === "on" || normalized === "off" || normalized === "status") {
     return normalized;
   }
-  return { error: "Usage: /codex_fast [on|off|status]" };
+  return { error: "Usage: /cas_fast [on|off|status]" };
+}
+
+function normalizeRegisteredCommandName(commandName: string): string {
+  return commandName.startsWith("cas_")
+    ? `codex_${commandName.slice("cas_".length)}`
+    : commandName;
 }
 
 function normalizeServiceTier(value: string | undefined | null): string | undefined {
@@ -956,13 +962,14 @@ export class CodexPluginController {
         : null;
     const binding = existingBinding ?? hydratedBinding?.binding ?? null;
     const args = ctx.args?.trim() ?? "";
+    const normalizedCommandName = normalizeRegisteredCommandName(commandName);
     if (isDiscordChannel(ctx.channel)) {
       this.api.logger.debug(
         `codex discord command /${commandName} from=${ctx.from ?? "<none>"} to=${ctx.to ?? "<none>"} conversation=${conversation?.conversationId ?? "<none>"}`,
       );
     }
 
-    switch (commandName) {
+    switch (normalizedCommandName) {
       case "codex_resume":
         return await this.handleJoinCommand(
           conversation,
@@ -1212,7 +1219,7 @@ export class CodexPluginController {
     }
     const prompt = args.trim();
     if (!prompt) {
-      return { text: "Usage: /codex_steer <message>" };
+      return { text: "Usage: /cas_steer <message>" };
     }
     const active = this.activeRuns.get(buildConversationKey(conversation));
     if (!active) {
@@ -1245,7 +1252,7 @@ export class CodexPluginController {
     }
     const prompt = parsed.prompt.trim();
     if (!prompt) {
-      return { text: "Usage: /codex_plan <goal> or /codex_plan off" };
+      return { text: "Usage: /cas_plan <goal> or /cas_plan off" };
     }
     const workspaceDir = resolveWorkspaceDir({
       bindingWorkspaceDir: binding?.workspaceDir,
@@ -1666,7 +1673,7 @@ export class CodexPluginController {
       ]);
     }
     if (buttons.length === 0) {
-      return { text: "Usage: /codex_rename [--sync] <new name>", buttons: [] };
+      return { text: "Usage: /cas_rename [--sync] <new name>", buttons: [] };
     }
     return {
       text: syncTopic


### PR DESCRIPTION
## Summary

I changed the plugin slash commands from `/codex_*` to `/cas_*`.
I updated the README and plugin metadata to describe this as an unnamed OpenClaw plugin for the Codex App Server protocol, and to make it explicit that references to Codex are descriptive only and not any claim of official OpenAI or Codex affiliation.

## Testing

I ran:

- `pnpm test`
- `pnpm typecheck`
