### PR TITLE
Plugin: drop cas command normalization

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -838,7 +838,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("shows codex_status as none when no core binding exists", async () => {
+  it("shows cas_status as none when no core binding exists", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
@@ -868,7 +868,7 @@ describe("Discord controller flows", () => {
     expect(reply.text).not.toContain("Session: session-1");
   });
 
-  it("does not hydrate a denied pending bind into codex_status", async () => {
+  it("does not hydrate a denied pending bind into cas_status", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertPendingBind({
       conversation: {
@@ -899,7 +899,7 @@ describe("Discord controller flows", () => {
     })).toBeNull();
   });
 
-  it("shows plan mode on in codex_status when the bound conversation has an active plan run", async () => {
+  it("shows plan mode on in cas_status when the bound conversation has an active plan run", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
@@ -941,7 +941,7 @@ describe("Discord controller flows", () => {
     expect(reply.text).toContain("Plan mode: on");
   });
 
-  it("parses unicode em dash --sync for codex_rename and renames the Telegram topic", async () => {
+  it("parses unicode em dash --sync for cas_rename and renames the Telegram topic", async () => {
     const { controller, clientMock, renameTopic } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
@@ -985,7 +985,7 @@ describe("Discord controller flows", () => {
     expect(reply).toEqual({ text: 'Renamed the Codex thread to "New Topic Name".' });
   });
 
-  it("parses unicode em dash --sync for codex_resume and renames the Telegram topic", async () => {
+  it("parses unicode em dash --sync for cas_resume and renames the Telegram topic", async () => {
     const { controller, renameTopic, sendMessageTelegram } = await createControllerHarness();
 
     const reply = await controller.handleCommand(
@@ -1127,7 +1127,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("replays pending codex_resume --sync effects after approval hydrates on the next resume command", async () => {
+  it("replays pending cas_resume --sync effects after approval hydrates on the next resume command", async () => {
     const { controller, clientMock, renameTopic, sendMessageTelegram } = await createControllerHarness();
     (controller as any).client.readThreadContext = vi.fn(async () => ({
       lastUserMessage: "What were we doing here?",
@@ -1200,7 +1200,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("retries an incomplete codex_resume bind before falling back to the picker", async () => {
+  it("retries an incomplete cas_resume bind before falling back to the picker", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertPendingBind({
       conversation: {
@@ -1240,7 +1240,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("rebinds an incomplete codex_resume bind when the retry is approved immediately", async () => {
+  it("rebinds an incomplete cas_resume bind when the retry is approved immediately", async () => {
     const { controller, renameTopic, sendMessageTelegram } = await createControllerHarness();
     (controller as any).client.readThreadContext = vi.fn(async () => ({
       lastUserMessage: "What were we doing here?",
@@ -1592,7 +1592,7 @@ describe("Discord controller flows", () => {
     });
   });
 
-  it("offers compact rename style buttons for codex_rename --sync without a name", async () => {
+  it("offers compact rename style buttons for cas_rename --sync without a name", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
@@ -2007,7 +2007,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("supports codex_plan off to interrupt an active plan run", async () => {
+  it("supports cas_plan off to interrupt an active plan run", async () => {
     const { controller } = await createControllerHarness();
     const interrupt = vi.fn(async () => {});
     (controller as any).activeRuns.set("discord::default::channel:chan-1::", {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -397,12 +397,6 @@ function parseFastAction(
   return { error: "Usage: /cas_fast [on|off|status]" };
 }
 
-function normalizeRegisteredCommandName(commandName: string): string {
-  return commandName.startsWith("cas_")
-    ? `codex_${commandName.slice("cas_".length)}`
-    : commandName;
-}
-
 function normalizeServiceTier(value: string | undefined | null): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized ? normalized : undefined;
@@ -1013,15 +1007,14 @@ export class CodexPluginController {
         : null;
     const binding = existingBinding ?? hydratedBinding?.binding ?? null;
     const args = ctx.args?.trim() ?? "";
-    const normalizedCommandName = normalizeRegisteredCommandName(commandName);
     if (isDiscordChannel(ctx.channel)) {
       this.api.logger.debug(
         `codex discord command /${commandName} from=${ctx.from ?? "<none>"} to=${ctx.to ?? "<none>"} conversation=${conversation?.conversationId ?? "<none>"}`,
       );
     }
 
-    switch (normalizedCommandName) {
-      case "codex_resume":
+    switch (commandName) {
+      case "cas_resume":
         return await this.handleJoinCommand(
           conversation,
           binding,
@@ -1031,7 +1024,7 @@ export class CodexPluginController {
           pendingBind,
           hydratedBinding?.pendingBind,
         );
-      case "codex_detach":
+      case "cas_detach":
         if (!conversation) {
           return { text: "This command needs a Telegram or Discord conversation." };
         }
@@ -1042,39 +1035,39 @@ export class CodexPluginController {
             ? "Detached this conversation from Codex."
             : "This conversation is not currently bound to Codex.",
         };
-      case "codex_status":
+      case "cas_status":
         return await this.handleStatusCommand(
           conversation,
           binding,
           Boolean(currentBinding || binding),
         );
-      case "codex_stop":
+      case "cas_stop":
         return await this.handleStopCommand(conversation);
-      case "codex_steer":
+      case "cas_steer":
         return await this.handleSteerCommand(conversation, args);
-      case "codex_plan":
+      case "cas_plan":
         return await this.handlePlanCommand(conversation, binding, args);
-      case "codex_review":
+      case "cas_review":
         return await this.handleReviewCommand(conversation, binding, args);
-      case "codex_compact":
+      case "cas_compact":
         return await this.handleCompactCommand(conversation, binding);
-      case "codex_skills":
+      case "cas_skills":
         return await this.handleSkillsCommand(conversation, binding, args);
-      case "codex_experimental":
+      case "cas_experimental":
         return await this.handleExperimentalCommand(binding);
-      case "codex_mcp":
+      case "cas_mcp":
         return await this.handleMcpCommand(binding, args);
-      case "codex_fast":
+      case "cas_fast":
         return await this.handleFastCommand(binding, args);
-      case "codex_model":
+      case "cas_model":
         return await this.handleModelCommand(conversation, binding, args);
-      case "codex_permissions":
+      case "cas_permissions":
         return await this.handlePermissionsCommand(binding);
-      case "codex_init":
+      case "cas_init":
         return await this.handlePromptAlias(conversation, binding, args, "/init");
-      case "codex_diff":
+      case "cas_diff":
         return await this.handlePromptAlias(conversation, binding, args, "/diff");
-      case "codex_rename":
+      case "cas_rename":
         return await this.handleRenameCommand(conversation, binding, args);
       default:
         return { text: "Unknown Codex command." };


### PR DESCRIPTION
## Summary
- remove the temporary command-name normalization layer in the controller
- dispatch directly on the registered `/cas_*` command names
- rename the remaining stale test descriptions so they match the published command surface

## Validation
- `pnpm test`
- `pnpm typecheck`
