### PR TITLE
Plugin: show plugin version in `/cas_status`

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi, PluginCommandContext } from "openclaw/plugin-sdk";
 import { CodexAppServerClient } from "./client.js";
@@ -189,6 +190,10 @@ async function createControllerHarnessWithoutLegacyBindings() {
     api: harness.api,
   };
 }
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version?: string };
+const TEST_PLUGIN_VERSION = packageJson.version ?? "unknown";
 
 function buildDiscordCommandContext(
   overrides: Partial<PluginCommandContext> & Record<string, unknown> = {},
@@ -864,6 +869,7 @@ describe("Discord controller flows", () => {
     );
 
     expect(reply.text).toContain("Binding: none");
+    expect(reply.text).toContain(`Plugin version: ${TEST_PLUGIN_VERSION}`);
     expect(reply.text).not.toContain("Project folder: /repo/discrawl");
     expect(reply.text).not.toContain("Session: session-1");
   });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -86,6 +87,17 @@ type ActiveRunRecord = {
 };
 
 const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const PLUGIN_VERSION = (() => {
+  try {
+    const packageJson = require("../package.json") as { version?: unknown };
+    return typeof packageJson.version === "string" && packageJson.version.trim()
+      ? packageJson.version.trim()
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+})();
 
 type PickerRender = {
   text: string;
@@ -3392,6 +3404,7 @@ export class CodexPluginController {
     );
 
     return formatCodexStatusText({
+      pluginVersion: PLUGIN_VERSION,
       threadState,
       account,
       rateLimits: limits,

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexPlanMarkdownPreview,
@@ -17,6 +18,10 @@ import {
   formatThreadButtonLabel,
   parseCodexReviewOutput,
 } from "./format.js";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version?: string };
+const TEST_PLUGIN_VERSION = packageJson.version ?? "unknown";
 
 function shortenHomePathForTest(value: string): string {
   const home = os.homedir();
@@ -97,6 +102,7 @@ describe("formatBoundThreadSummary", () => {
 describe("formatCodexStatusText", () => {
   it("matches the old operational Codex status shape", () => {
     const text = formatCodexStatusText({
+      pluginVersion: TEST_PLUGIN_VERSION,
       bindingActive: true,
       threadState: {
         threadId: "019cc00d-6cf4-7c11-afcd-2673db349a21",
@@ -134,6 +140,7 @@ describe("formatCodexStatusText", () => {
     });
 
     expect(text).toContain("Binding: active");
+    expect(text).toContain(`Plugin version: ${TEST_PLUGIN_VERSION}`);
     expect(text).toContain("Thread: Fix Telegram approval flow");
     expect(text).toContain("Model: openai/gpt-5.4 · reasoning high");
     expect(text).toContain(

--- a/src/format.ts
+++ b/src/format.ts
@@ -480,6 +480,7 @@ export function formatCodexContextUsageSnapshot(
 }
 
 export function formatCodexStatusText(params: {
+  pluginVersion?: string;
   threadState?: ThreadState;
   account?: AccountSummary | null;
   rateLimits: RateLimitSummary[];
@@ -491,6 +492,9 @@ export function formatCodexStatusText(params: {
 }): string {
   const lines = [];
   lines.push(`Binding: ${params.bindingActive ? "active" : "none"}`);
+  if (params.pluginVersion?.trim()) {
+    lines.push(`Plugin version: ${params.pluginVersion.trim()}`);
+  }
   if (params.threadState?.threadName?.trim()) {
     lines.push(`Thread: ${params.threadState.threadName.trim()}`);
   }


### PR DESCRIPTION
## Summary

I updated `/cas_status` to print the plugin package version from `package.json` and label it clearly as `Plugin version`.

I threaded the package version through the status formatter and added tests that cover both the formatter output and the `/cas_status` command output.

## Validation

I ran:

- `pnpm test`
- `pnpm typecheck`
