### PR TITLE
Plugin: trim shell launcher wrappers from command approvals

### DIFF
--- a/src/pending-input.test.ts
+++ b/src/pending-input.test.ts
@@ -11,6 +11,7 @@ import {
   questionnaireIsComplete,
   requestToken,
   stripShellLauncher,
+  extractCommandFromActions,
 } from "./pending-input.js";
 
 describe("pending-input helpers", () => {
@@ -282,6 +283,56 @@ Guidance:
     // Non-launcher commands pass through unchanged
     expect(stripShellLauncher("git status")).toBe("git status");
     expect(stripShellLauncher("npm install")).toBe("npm install");
+  });
+
+  it("extracts display command from commandActions array", () => {
+    // Single action with type "unknown"
+    expect(
+      extractCommandFromActions({
+        commandActions: [{ type: "unknown", command: "git status" }],
+      }),
+    ).toBe("git status");
+
+    // Single action with type "read"
+    expect(
+      extractCommandFromActions({
+        commandActions: [{ type: "read", command: "cat README.md", name: "README.md", path: "README.md" }],
+      }),
+    ).toBe("cat README.md");
+
+    // Multiple actions joined with &&
+    expect(
+      extractCommandFromActions({
+        commandActions: [
+          { type: "unknown", command: "git add README.md" },
+          { type: "unknown", command: 'git commit -m "docs: update"' },
+        ],
+      }),
+    ).toBe('git add README.md && git commit -m "docs: update"');
+
+    // Empty array returns undefined
+    expect(extractCommandFromActions({ commandActions: [] })).toBeUndefined();
+
+    // Missing commandActions returns undefined
+    expect(extractCommandFromActions({ command: "/bin/zsh -lc 'git status'" })).toBeUndefined();
+
+    // null/undefined params
+    expect(extractCommandFromActions(null)).toBeUndefined();
+    expect(extractCommandFromActions(undefined)).toBeUndefined();
+
+    // Actions with missing command field are filtered out
+    expect(
+      extractCommandFromActions({
+        commandActions: [{ type: "unknown" }, { type: "read", command: "cat foo.txt", name: "foo.txt", path: "foo.txt" }],
+      }),
+    ).toBe("cat foo.txt");
+
+    // All actions missing command field returns undefined
+    expect(
+      extractCommandFromActions({
+        commandActions: [{ type: "unknown" }],
+      }),
+    ).toBeUndefined();
   });
 
   it("parses structured request_user_input questions into questionnaire state", () => {

--- a/src/pending-input.ts
+++ b/src/pending-input.ts
@@ -663,6 +663,34 @@ export function stripShellLauncher(command: string): string {
   return command;
 }
 
+/**
+ * Extracts a display command from the app-server's `commandActions` array.
+ *
+ * The app-server protocol provides `commandActions` as "best-effort parsed
+ * command actions for friendly display" (see CommandAction type in
+ * codex-rs/app-server-protocol). Each action has a `.command` field that is
+ * already stripped of shell launcher wrappers by the Rust-side parser
+ * (extract_shell_command → strip_bash_lc_and_escape).
+ *
+ * When available, this is more reliable than regex-based stripping because
+ * the upstream parser uses tree-sitter for proper shell parsing.
+ */
+export function extractCommandFromActions(requestParams: unknown): string | undefined {
+  const record = asRecord(requestParams);
+  if (!record) return undefined;
+  const actions = record.commandActions;
+  if (!Array.isArray(actions) || actions.length === 0) return undefined;
+  const commands = actions
+    .map((a: unknown) => {
+      const action = asRecord(a);
+      if (!action || typeof action.command !== "string") return undefined;
+      return action.command;
+    })
+    .filter((c): c is string => c !== undefined);
+  if (commands.length === 0) return undefined;
+  return commands.join(" && ");
+}
+
 export function buildPendingPromptText(params: {
   method: string;
   requestId: string;
@@ -691,7 +719,11 @@ export function buildPendingPromptText(params: {
       ),
     );
   }
-  const command =
+  // Prefer the pre-parsed commandActions from the app-server protocol when
+  // available — the Rust side already strips shell launchers via tree-sitter.
+  // Fall back to regex-based stripShellLauncher on the raw command string.
+  const displayCommand = extractCommandFromActions(params.requestParams);
+  const rawCommand =
     findFirstStringByKeys(params.requestParams, [
       "command",
       "cmd",
@@ -699,8 +731,9 @@ export function buildPendingPromptText(params: {
       "rawCommand",
       "shellCommand",
     ]) ?? "";
+  const command = displayCommand ?? (rawCommand ? stripShellLauncher(rawCommand) : "");
   if (command) {
-    lines.push("", "Command:", "", buildMarkdownCodeBlock(stripShellLauncher(command), "sh"));
+    lines.push("", "Command:", "", buildMarkdownCodeBlock(command, "sh"));
   }
   const grantRoot = findFirstStringByKeys(params.requestParams, ["grantRoot", "grant_root"]);
   if (grantRoot) {


### PR DESCRIPTION
## Summary

Strips `/bin/zsh -lc '...'`, `bash -lc '...'`, and similar shell launcher wrappers from the Command block in approval prompts, matching the display behavior of Codex Desktop and CLI.

## Why this matters

Command approval prompts currently show the full shell invocation:

```
/bin/zsh -lc 'git add README.md && git commit -m "docs: simplify README opening"'
```

The shell launcher is an implementation detail — users shouldn't need to read past it to understand what Codex is about to run. The expected display is:

```
git add README.md && git commit -m "docs: simplify README opening"
```

This matches upstream behavior documented in [#9](https://github.com/pwrdrvr/openclaw-codex-app-server/issues/9), which identifies `strip_bash_lc_and_escape()` in `codex-rs/tui/src/exec_command.rs` as the reference implementation.

## Changes

- Added `stripShellLauncher(command: string): string` to `src/pending-input.ts`. Detects the pattern `[/path/]shell -lc '...'` using a single regex covering `bash`, `zsh`, `sh`, `dash`, `ksh`, `tcsh`, and `fish` with or without an absolute path prefix. Falls back to the raw command if no match.
- Applied `stripShellLauncher()` in `buildPendingPromptText()` (`src/pending-input.ts:703`) before passing to `buildMarkdownCodeBlock`. The raw command is unchanged for approval transport — only the display is simplified.
- Exported `stripShellLauncher` so it can be tested directly.

## Testing

Added 7 test cases to `src/pending-input.test.ts` covering:
- `/bin/zsh -lc '...'`
- `/bin/bash -lc '...'`
- `bash -lc '...'`
- `zsh -lc '...'` with double-quoted inner content
- `/usr/bin/zsh -lc '...'`
- Plain commands that pass through unchanged (`git status`, `npm install`)

All 122 tests pass (`pnpm typecheck` + `pnpm test`).

Fixes #9

This contribution was developed with AI assistance (Claude Code).