### PR TITLE
Plugin: detect and reject stale worktree paths on resume

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -320,6 +320,39 @@ describe("Discord controller flows", () => {
     );
   });
 
+  it("rejects resume when the thread worktree path no longer exists on disk", async () => {
+    const { controller, clientMock } = await createControllerHarness();
+    const missingWorktreePath = "/tmp/worktrees/bold-bartik/repo-name";
+    clientMock.listThreads.mockResolvedValue([
+      {
+        threadId: "thread-stale",
+        title: "Stale Worktree Thread",
+        projectKey: missingWorktreePath,
+        createdAt: Date.now() - 60_000,
+        updatedAt: Date.now() - 30_000,
+      },
+    ]);
+    clientMock.readThreadState.mockResolvedValue({
+      threadId: "thread-stale",
+      threadName: "Stale Worktree Thread",
+      model: "openai/gpt-5.4",
+      cwd: missingWorktreePath,
+      serviceTier: "default",
+    });
+
+    const reply = await controller.handleCommand(
+      "cas_resume",
+      buildTelegramCommandContext({
+        args: "thread-stale",
+        commandBody: "/cas_resume thread-stale",
+      }),
+    );
+
+    expect(reply.text).toContain("Cannot resume");
+    expect(reply.text).toContain(missingWorktreePath);
+    expect(reply.text).toContain("no longer exists on disk");
+  });
+
   it("sends Discord model pickers directly instead of returning Telegram buttons", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
     await (controller as any).store.upsertBinding({

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { promises as fs } from "node:fs";
+import { existsSync, promises as fs } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -3226,6 +3226,12 @@ export class CodexPluginController {
       return {
         status: "error",
         message: "This action can only bind from a live command or interactive context.",
+      };
+    }
+    if (params.workspaceDir && this.isWorktreePath(params.workspaceDir) && !existsSync(params.workspaceDir)) {
+      return {
+        status: "error",
+        message: `Cannot resume: workspace path no longer exists on disk.\n\`${params.workspaceDir}\`\n\nThe worktree may have been removed. Check your local paths or start a new session.`,
       };
     }
     const approval = await requestBinding({


### PR DESCRIPTION
## Summary

Adds an early guard in `requestConversationBinding()` (`src/controller.ts`) that checks whether a worktree-shaped workspace path still exists on disk before binding the conversation. Returns a clear error immediately instead of letting Codex fail later with a cryptic shell or git error.

## Why this matters

From [#27](https://github.com/pwrdrvr/openclaw-codex-app-server/issues/27): a thread can be resumed even if its recorded `cwd` no longer exists. The failure only shows up later when Codex tries to execute shell commands in the missing directory — at which point the error is confusing and hard to connect back to the missing worktree.

Early detection turns a cryptic downstream failure into an immediate, actionable message:

```
Cannot resume: workspace path no longer exists on disk.
`/path/to/worktrees/bold-bartik/repo`

The worktree may have been removed. Check your local paths or start a new session.
```

## Changes

- `src/controller.ts`: added `existsSync` import from `node:fs`. Added guard in `requestConversationBinding()` (right after the `!requestBinding` check) that returns `{ status: "error" }` if the workspace path matches the worktree pattern and doesn't exist on disk.
- `src/controller.test.ts`: added a test covering resume with a nonexistent worktree path — asserts the error reply is returned before any binding proceeds.

The check is scoped to worktree-shaped paths (`/worktrees/branch/repo`) using the existing `isWorktreePath()` helper, avoiding false positives on configurable workspace roots that may not be local paths.

## Testing

All 122 tests pass (`pnpm typecheck` + `pnpm test`).

Fixes #27

This contribution was developed with AI assistance (Claude Code).