### PR TITLE
Discord: fix `/codex_resume` identity resolution in brand-new threads

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -353,6 +353,33 @@ describe("Discord controller flows", () => {
     expect(reply.text).toContain("no longer exists on disk");
   });
 
+  it("resolves channel identity from ctx.to when ctx.from is a slash identity in a new Discord thread", async () => {
+    // Regression test for brand-new Discord threads where the slash interaction
+    // places the slash user identity in ctx.from and the channel target in ctx.to.
+    const { controller, sendComponentMessage } = await createControllerHarness();
+
+    const reply = await controller.handleCommand(
+      "cas_resume",
+      buildDiscordCommandContext({
+        from: "slash:user-1",
+        to: "discord:channel:chan-1",
+      }),
+    );
+
+    expect(reply).toEqual({
+      text: "Sent a Codex thread picker to this Discord conversation.",
+    });
+    expect(sendComponentMessage).toHaveBeenCalledWith(
+      "channel:chan-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Showing recent Codex sessions"),
+      }),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
+
   it("sends Discord model pickers directly instead of returning Telegram buttons", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
     await (controller as any).store.upsertBinding({

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -271,7 +271,12 @@ function toConversationTargetFromCommand(ctx: PluginCommandContext): Conversatio
     };
   }
   if (isDiscordChannel(ctx.channel)) {
-    const conversationId = normalizeDiscordConversationId(ctx.from ?? ctx.to);
+    // In brand-new Discord threads, the slash interaction may place the slash
+    // user identity in ctx.from (e.g. "slash:user-id") while ctx.to holds the
+    // real channel target. Prefer ctx.to when ctx.from is a slash identity so
+    // /cas_resume resolves to the correct channel from the first attempt.
+    const sourceId = ctx.from?.startsWith("slash:") ? ctx.to : (ctx.from ?? ctx.to);
+    const conversationId = normalizeDiscordConversationId(sourceId);
     if (!conversationId) {
       return null;
     }


### PR DESCRIPTION
## Summary

Fixes `/cas_resume` failing on the first attempt in brand-new Discord threads by correcting the identity resolution in `toConversationTargetFromCommand()`.

## Why this matters

From [#30](https://github.com/pwrdrvr/openclaw-codex-app-server/issues/30): in a brand-new Discord thread, sending a first message before the agent has replied causes `/cas_resume` to show a generic "No active Codex sessions found" reply, with the picker only appearing ~40 seconds later via a retry.

Root cause: the slash interaction placed the slash user identity (e.g. `slash:user-id`) in `ctx.from`, with the real channel target in `ctx.to`. The expression `ctx.from ?? ctx.to` evaluated to `"slash:user-id"` (truthy string). `normalizeDiscordConversationId()` maps any `slash:` prefix to `undefined`, so `toConversationTargetFromCommand()` returned `null` — and the command could not resolve a conversation target for the picker.

## Changes

`src/controller.ts`, `toConversationTargetFromCommand()` (line ~274): when `ctx.from` starts with `"slash:"`, use `ctx.to` as the channel source instead of `ctx.from`. Established-channel behavior is unchanged — when `ctx.from` holds a `discord:channel:` or `channel:` identity, it continues to take precedence.

```diff
-    const conversationId = normalizeDiscordConversationId(ctx.from ?? ctx.to);
+    const sourceId = ctx.from?.startsWith("slash:") ? ctx.to : (ctx.from ?? ctx.to);
+    const conversationId = normalizeDiscordConversationId(sourceId);
```

## Testing

Added a regression test in `src/controller.test.ts` with `ctx.from = "slash:user-1"` and `ctx.to = "discord:channel:chan-1"` — asserts the thread picker is sent to the correct channel identity (`"channel:chan-1"`), not a null target.

All 122 tests pass (`pnpm typecheck` + `pnpm test`).

Fixes #30

This contribution was developed with AI assistance (Claude Code).