### PR TITLE
Skill: refine OCAS regression workflow

### DIFF
--- a/.agents/skills/test-ocas-openclaw/SKILL.md
+++ b/.agents/skills/test-ocas-openclaw/SKILL.md
@@ -10,7 +10,8 @@ Use this skill for manual regression passes of this plugin against a real local 
 ## Preconditions
 
 - Confirm the plugin branch under test is linked into the local OpenClaw checkout and OpenClaw is running.
-- If the test uses Telegram Web, use [$agent-browser](https://github.com/vercel-labs/agent-browser) from `~/.agents/skills/agent-browser`.
+- Prefer Playwright MCP or Chrome MCP for Telegram Web. It was more reliable than `agent-browser` in recent passes.
+- Use [$agent-browser](https://github.com/vercel-labs/agent-browser) only as fallback. Read [references/agent-browser.md](references/agent-browser.md) only if you intentionally choose that path.
 - If Telegram Web or Discord is not logged in, stop and ask the user to complete login.
 - Prefer a low-risk Codex thread unless the user asks otherwise. In this repo, `discrawl` and `dupcanon` are safe defaults for resume tests.
 
@@ -27,8 +28,16 @@ Read them when:
 - plan mode appears stuck
 - a questionnaire should exist but Telegram Web does not render it
 - slash replies appear in the wrong chat or topic
+- answer buttons appear but the active pending request does not advance
 
 Treat the state files as diagnostic evidence, not as a thing to hand-edit.
+
+## Preferred Browser Path
+
+- Keep the browser anchored to the requested topic or channel for the full pass.
+- For Telegram topics, keep the topic fragment in the URL when possible.
+- If the UI looks stale but local state shows the expected pending request or callbacks, refresh Telegram Web with `Cmd+R` before calling it a backend bug.
+- Separate browser-navigation failures from OCAS failures. A browser can drift to `General` or the chat list without proving an OCAS routing bug.
 
 ## Regression Flow
 
@@ -36,7 +45,7 @@ Treat the state files as diagnostic evidence, not as a thing to hand-edit.
 
 - Stay in the requested group, DM, channel, or topic for the entire pass.
 - If the expected Telegram topic is missing, check whether `/cas_resume --sync` renamed it. Rename it back or create a fresh test topic if needed.
-- If slash-command routing leaks into `General`, log that as a bug and move the browser back to the intended topic before continuing.
+- If slash-command routing leaks into `General`, log that separately and move the browser back to the intended topic before continuing.
 
 2. Baseline the conversation.
 
@@ -70,35 +79,43 @@ I want you to run `npm view dive` and make sure to ask to exit the sandbox as it
 - Expect a code-formatted command area that shows `npm view dive`.
 - Verify the displayed command is trimmed for presentation and does not leak a shell-launcher wrapper like `/bin/zsh -lc ...`.
 - After verifying the dialog, approve the command with `Approve Once` or the platform-equivalent approval button so later tests are not blocked by a stale pending approval.
-- If the model only asks a conversational question like "Do you want to allow..." without rendering execution approval controls, treat that test as invalid and rerun with the exact prompt above.
+- If the model only asks a conversational question like `Do you want to allow...` without rendering execution approval controls, treat that test as invalid and rerun with the exact prompt above.
 
-5. Verify plan mode.
+5. Verify long-running review behavior before plan mode.
+
+- Run `/cas_review` before `/cas_plan`.
+- Treat `/cas_review` as a long-running request. It may take several minutes.
+- Do not interrupt `/cas_review` by starting `/cas_plan`, `/cas_compact`, or other long-running flows while review is active.
+- After starting review, wait 30 seconds at a time and check for output again.
+- Record whether review immediately skips expected desktop-style base and branch questions. That is a behavior gap, but not the same thing as a review failure.
+
+6. Verify plan mode only after review has finished.
 
 - Use `/cas_plan <prompt>`. Do not test plan mode by sending the raw prompt without the command.
-- Use a short questionnaire prompt first. A breakfast-choice prompt is good because it exercises `Prev`, `Next`, and a final Implement button.
+- Use a short questionnaire prompt first. A breakfast-choice prompt is good because it exercises question rendering and answer submission.
 - Expect:
   - questionnaire text
   - answer buttons
-  - `Prev` and `Next` navigation when appropriate
-  - final `Implement this plan?` buttons
+  - question progression when answering
+  - final `Implement this plan` controls
+- If question 1 renders but button clicks or plain-text answers do not advance the active pending request in `state.json`, record that as a real failure.
 - If plan mode gets stuck, `/cas_plan off` should exit it.
 
-6. Verify long-plan truncation.
+7. Verify long-plan truncation.
 
 - Ask for a final plan longer than 4000 characters.
 - Expect the Telegram preview to truncate and the plugin to attach the full Markdown plan when needed.
 
-7. Cover other control commands as needed.
+8. Cover other control commands as needed.
 
-- `/cas_review`
-  - Expected desktop-style base and branch questions may be missing. Log that if review starts immediately.
 - `/cas_mcp`
   - Expect a list of configured MCP servers.
 - `/cas_skills`
-  - Expect installed skills. Current behavior may duplicate a text list plus buttons; log that as a display issue rather than a blocker.
+  - Expect installed skills.
+  - If the response shows both a full text list and buttons for the same skills, record a display bug rather than a blocker.
 - `/cas_model`
   - Expect model list and selection controls.
-  - Model selection may not fully reflect back into `/cas_status` yet; log that mismatch.
+  - Model selection may not fully reflect back into `/cas_status` yet. Record that mismatch.
 - `/cas_fast`
   - Verify `on`, `off`, and `status` behavior when the conversation is bound.
 - `/cas_compact`
@@ -107,18 +124,38 @@ I want you to run `npm view dive` and make sure to ask to exit the sandbox as it
   - Verify thread rename and, if requested, `--sync` topic rename behavior.
 - `/cas_diff`, `/cas_permissions`, `/cas_init`
   - Verify current forward-or-placeholder behavior instead of assuming full implementation.
+  - Treat known-placeholder behavior as neutral, not as a regression, unless the user says the command should already work.
 
-8. Clean up.
+9. Clean up.
 
 - End by running `/cas_detach`.
 - Confirm the conversation is no longer bound.
+- Confirm the topic has no lingering pending request in `state.json` if plan mode or approvals were exercised.
+
+## Result Legend
+
+- `✅` Pass. Behavior matched what should work now.
+- `❌` Fail. Behavior should work now and did not.
+- `➖` Neutral. The command is known to be unimplemented, placeholder-only, or intentionally incomplete.
+
+Use a flat results table while testing:
+
+| Area | Status | Observed | Notes |
+| --- | --- | --- | --- |
+| `/cas_status` | `✅` | Bound topic reply in-topic | Include thread, model, and plugin version |
+| Approval dialog | `✅` | Real execution approval with trimmed `npm view dive` | Approve after verifying |
+| `/cas_review` | `✅` or `❌` | Long-running review | Wait 30s between checks |
+| `/cas_plan` render | `✅` or `❌` | Question text and buttons | Separate render from answer submission |
+| `/cas_plan` answer submission | `✅` or `❌` | Active request advances or stays stuck | Compare against `pendingRequests` |
+| `/cas_diff` | `➖` or `❌` | Placeholder or real command | Use `➖` if still knowingly unimplemented |
 
 ## Gotchas
 
 - Telegram Web can go stale. If a simple request appears hung for more than about one minute, and the local state file already shows the pending questionnaire or callbacks, refresh Telegram Web with `Cmd+R` before calling it a backend bug.
 - Plain text can still route correctly even when slash commands from a topic leak to `General`. Record both facts separately.
 - A core binding can exist in `thread-bindings-default.json` while plugin-local state is stale or missing. Compare both files before concluding which side is wrong.
-- Keep the browser anchored to the correct topic. It is easy to drift into `General` or the chat list while testing.
+- Telegram can leave stale questionnaire buttons visible in the DOM. If a click produces `No active Codex run is waiting for input.` but `pendingRequests` still shows the active questionnaire unchanged, record that the visible button press did not reach the active request.
+- Starting `/cas_plan` while `/cas_review` is still running can interrupt the review. Avoid that sequence during normal regression passes.
 
 ## Evidence To Capture
 
@@ -127,6 +164,7 @@ I want you to run `npm view dive` and make sure to ask to exit the sandbox as it
 - Whether the reply was plain text, buttons, or an attachment
 - Relevant snippets from `state.json` and `thread-bindings-default.json` when UI behavior is suspicious
 - Known-good versus observed behavior
+- The result-table row for each command or flow tested
 
 ## Formal Bug Notes
 

--- a/.agents/skills/test-ocas-openclaw/references/agent-browser.md
+++ b/.agents/skills/test-ocas-openclaw/references/agent-browser.md
@@ -1,0 +1,26 @@
+# Agent Browser Fallback Notes
+
+Read this file only if you intentionally choose [$agent-browser](https://github.com/vercel-labs/agent-browser) instead of Playwright MCP or Chrome MCP.
+
+## Current Recommendation
+
+- Treat `agent-browser` as fallback-only for Telegram Web.
+- Prefer Playwright MCP or Chrome MCP for the primary regression pass.
+
+## Known Problems
+
+- The browser can drift out of the intended topic and back to the chat list or `General`.
+- Slash-command replies can appear in `General` even when the intended target was a topic.
+- Telegram Web can show stale UI until a manual refresh.
+
+## Workarounds
+
+- Reload the page before a serious test pass.
+- Keep the topic fragment in the URL when possible. For example, a topic URL can look like `#-1003841603622_3509`.
+- If the page drops the topic fragment or navigates away from the topic, re-enter the topic before sending the next command.
+- If a simple request appears hung for more than about one minute, check `~/.openclaw/openclaw-codex-app-server/state.json`. If the pending request already exists there, refresh with `Cmd+R`.
+
+## Interpretation Guidance
+
+- Do not blame OCAS for topic drift until you confirm the browser is actually still in the intended topic.
+- If plain text works in-topic but slash commands leak elsewhere only under `agent-browser`, treat that as likely browser-automation interference until proven otherwise.


### PR DESCRIPTION
## Summary

I updated the `test-ocas-openclaw` skill based on the live baseline regression pass we just ran against Telegram/OpenClaw.

- I made Playwright MCP / Chrome MCP the preferred Telegram path and moved `agent-browser` notes into a separate reference file that only needs to be loaded when that fallback path is used.
- I documented that `/cas_review` is a long-running flow, should be polled every 30 seconds, and should be allowed to finish before starting `/cas_plan`.
- I added a results legend and results table guidance so future manual passes clearly distinguish working behavior, real failures, and known-unimplemented placeholders such as `/cas_diff`.
- I captured the plan-mode failure we observed where question rendering worked but answer submission did not advance the active pending request.

## Validation

- I updated the skill from the observed live baseline behavior in Telegram using Playwright MCP.
- I verified the skill frontmatter and `agents/openai.yaml` with a lightweight Ruby YAML parse.
- I confirmed the fallback reference file exists and is linked from the main skill.

## Notes

- The repo does not contain a local `scripts/quick_validate.py`.
- The system `quick_validate.py` could not run fully in this environment because the local Python install is missing `PyYAML`.
