### PR TITLE
Plugin: add cancel button to /cas_resume picker

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -2587,4 +2587,55 @@ describe("Discord controller flows", () => {
     );
     expect(clientMock.readAccount).not.toHaveBeenCalled();
   });
+
+  it("dismisses the picker when cancel-picker callback is pressed", async () => {
+    const { controller } = await createControllerHarness();
+    const callback = await (controller as any).store.putCallback({
+      kind: "cancel-picker",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+    });
+    const acknowledge = vi.fn(async () => {});
+    const editMessage = vi.fn(async () => {});
+
+    await controller.handleDiscordInteractive({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "interaction-1",
+      conversationId: "channel:chan-1",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "button",
+        data: `codexapp:${callback.token}`,
+        namespace: "codexapp",
+        payload: callback.token,
+        messageId: "message-1",
+      },
+      senderId: "user-1",
+      senderUsername: "Ada",
+      respond: {
+        acknowledge,
+        reply: vi.fn(async () => {}),
+        followUp: vi.fn(async () => {}),
+        editMessage,
+        clearComponents: vi.fn(async () => {}),
+      },
+    } as any);
+
+    // editPicker uses ctx.respond.editMessage first; when that succeeds it calls
+    // registerBuiltDiscordComponentMessage instead of editDiscordComponentMessage
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(discordSdkState.registerBuiltDiscordComponentMessage).toHaveBeenCalledWith({
+      buildResult: expect.objectContaining({
+        components: expect.any(Array),
+        entries: expect.any(Array),
+      }),
+      messageId: "message-1",
+    });
+    // The callback should be removed from the store
+    expect((controller as any).store.getCallback(callback.token)).toBeNull();
+  });
 });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2665,10 +2665,18 @@ export class CodexPluginController {
         page: 0,
       },
     });
+    const cancel = await this.store.putCallback({
+      kind: "cancel-picker",
+      conversation: params.conversation,
+    });
     params.buttons.push([
       {
         text: params.projectName ? "Projects" : "Browse Projects",
         callback_data: `${INTERACTIVE_NAMESPACE}:${projects.token}`,
+      },
+      {
+        text: "Cancel",
+        callback_data: `${INTERACTIVE_NAMESPACE}:${cancel.token}`,
       },
     ]);
     return params.buttons;
@@ -2817,10 +2825,18 @@ export class CodexPluginController {
         page: 0,
       },
     });
+    const cancel = await this.store.putCallback({
+      kind: "cancel-picker",
+      conversation,
+    });
     buttons.push([
       {
         text: "Recent Sessions",
         callback_data: `${INTERACTIVE_NAMESPACE}:${recent.token}`,
+      },
+      {
+        text: "Cancel",
+        callback_data: `${INTERACTIVE_NAMESPACE}:${cancel.token}`,
       },
     ]);
 
@@ -3129,6 +3145,11 @@ export class CodexPluginController {
           error instanceof Error ? error.message : "Unable to derive a Codex thread name.",
         );
       }
+      return;
+    }
+    if (callback.kind === "cancel-picker") {
+      await this.store.removeCallback(callback.token);
+      await responders.editPicker({ text: "Picker dismissed.", buttons: [] });
       return;
     }
     const binding = this.store.getBinding(callback.conversation);

--- a/src/state.ts
+++ b/src/state.ts
@@ -77,6 +77,12 @@ type PutCallbackInput =
       text: string;
       token?: string;
       ttlMs?: number;
+    }
+  | {
+      kind: "cancel-picker";
+      conversation: ConversationTarget;
+      token?: string;
+      ttlMs?: number;
     };
 
 function toConversationKey(target: ConversationTarget): string {
@@ -319,14 +325,22 @@ export class PluginStateStore {
                   createdAt: now,
                   expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
                   }
-                : {
-                    kind: "reply-text",
-                    conversation: callback.conversation,
-                    text: callback.text,
-                    token: callback.token ?? this.createCallbackToken(),
-                    createdAt: now,
-                    expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
-                };
+                : callback.kind === "reply-text"
+                  ? {
+                      kind: "reply-text",
+                      conversation: callback.conversation,
+                      text: callback.text,
+                      token: callback.token ?? this.createCallbackToken(),
+                      createdAt: now,
+                      expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
+                    }
+                  : {
+                      kind: "cancel-picker",
+                      conversation: callback.conversation,
+                      token: callback.token ?? this.createCallbackToken(),
+                      createdAt: now,
+                      expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
+                    };
     this.snapshot.callbacks = this.snapshot.callbacks.filter(
       (current) => current.token !== entry.token,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -377,6 +377,13 @@ export type CallbackAction =
       syncTopic: boolean;
       createdAt: number;
       expiresAt: number;
+    }
+  | {
+      token: string;
+      kind: "cancel-picker";
+      conversation: ConversationRef;
+      createdAt: number;
+      expiresAt: number;
     };
 
 export type StoreSnapshot = {


### PR DESCRIPTION
## Summary

Add a "Cancel" button to the `/cas_resume` thread picker and project picker so users can dismiss the picker without selecting a thread.

## Changes

- Add `cancel-picker` callback kind to `CallbackAction` type (`src/types.ts`)
- Add `cancel-picker` to `PutCallbackInput` and its mapping in `store.putCallback` (`src/state.ts`)
- Add Cancel button in `appendThreadPickerControls` (thread picker) and `renderProjectPicker` (project picker) (`src/controller.ts`)
- Handle `cancel-picker` in `dispatchCallbackAction`: edits the picker message to "Picker dismissed." and removes the callback
- Add test for Discord cancel-picker callback flow (`src/controller.test.ts`)

The Cancel button appears on the same row as the "Browse Projects" / "Recent Sessions" button, so it's always visible on every picker page.

## Testing

- `pnpm typecheck` passes
- All 126 tests pass (125 existing + 1 new)

Fixes #37

This contribution was developed with AI assistance (Claude Code).