### PR TITLE
Plugin: fall back to global recent threads when /cas_resume workspace is empty

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2681,10 +2681,22 @@ export class CodexPluginController {
     page: number,
     projectName?: string,
   ): Promise<PickerRender> {
-    const { workspaceDir, threads } = await this.listPickerThreads(binding, {
+    let { workspaceDir, threads } = await this.listPickerThreads(binding, {
       parsed,
       projectName,
     });
+    let fallbackToGlobal = false;
+    if (threads.length === 0 && workspaceDir != null && !projectName) {
+      const globalResult = await this.client.listThreads({
+        sessionKey: binding?.sessionKey,
+        workspaceDir: undefined,
+        filter: parsed.query || undefined,
+      });
+      if (globalResult.length > 0) {
+        threads = globalResult;
+        fallbackToGlobal = true;
+      }
+    }
     const pageResult = paginateItems(threads, page);
     const distinctProjects = new Set(
       threads.map((thread) => getProjectName(thread.projectKey)).filter(Boolean),
@@ -2694,17 +2706,18 @@ export class CodexPluginController {
       conversation,
       syncTopic: parsed.syncTopic,
       threads: pageResult.items,
-      showProjectName: !projectName && distinctProjects.size > 1,
+      showProjectName: !projectName && (fallbackToGlobal || distinctProjects.size > 1),
       })) ?? [];
     return {
       text: formatThreadPickerIntro({
         page: pageResult.page,
         totalPages: pageResult.totalPages,
         totalItems: pageResult.totalItems,
-        includeAll: workspaceDir == null,
+        includeAll: workspaceDir == null || fallbackToGlobal,
         syncTopic: parsed.syncTopic,
-        workspaceDir,
+        workspaceDir: fallbackToGlobal ? undefined : workspaceDir,
         projectName,
+        fallbackToGlobal,
       }),
       buttons: await this.appendThreadPickerControls({
             conversation,

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -426,6 +426,30 @@ describe("formatThreadPickerIntro", () => {
 
     expect(text).toContain("sync the current channel/topic name");
   });
+
+  it("shows fallback message when workspace threads fell back to global", () => {
+    const text = formatThreadPickerIntro({
+      page: 0,
+      totalPages: 1,
+      totalItems: 5,
+      includeAll: true,
+      fallbackToGlobal: true,
+    });
+
+    expect(text).toContain("No threads in this workspace. Showing recent sessions from all projects.");
+  });
+
+  it("does not show fallback message for normal global listing", () => {
+    const text = formatThreadPickerIntro({
+      page: 0,
+      totalPages: 1,
+      totalItems: 5,
+      includeAll: true,
+    });
+
+    expect(text).not.toContain("No threads in this workspace");
+    expect(text).toContain("Showing recent Codex sessions across all projects.");
+  });
 });
 
 describe("formatSkills", () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -151,15 +151,18 @@ export function formatThreadPickerIntro(params: {
   syncTopic?: boolean;
   projectName?: string;
   workspaceDir?: string;
+  fallbackToGlobal?: boolean;
 }): string {
   const pageLabel = `Page ${params.page + 1}/${params.totalPages}`;
-  const scopeLabel = params.projectName
-    ? `Showing recent Codex sessions for ${params.projectName}.`
-    : params.includeAll
-      ? "Showing recent Codex sessions across all projects."
-      : params.workspaceDir
-        ? `Showing recent Codex sessions for ${getProjectName(params.workspaceDir) ?? "this project"}.`
-        : "Showing recent Codex sessions.";
+  const scopeLabel = params.fallbackToGlobal
+    ? "No threads in this workspace. Showing recent sessions from all projects."
+    : params.projectName
+      ? `Showing recent Codex sessions for ${params.projectName}.`
+      : params.includeAll
+        ? "Showing recent Codex sessions across all projects."
+        : params.workspaceDir
+          ? `Showing recent Codex sessions for ${getProjectName(params.workspaceDir) ?? "this project"}.`
+          : "Showing recent Codex sessions.";
   return [
     `${scopeLabel} ${pageLabel}.`,
     "Legend: 🌿 worktree, ✏️ uncommitted changes, U updated, C created.",


### PR DESCRIPTION
## Summary

When `/cas_resume` shows no threads for the current workspace, automatically fall back to showing recent threads from all workspaces instead of a dead-end "No matching Codex threads found." message.

## Changes

- Add fallback logic in `renderThreadPicker` (`src/controller.ts`): when workspace-scoped `listPickerThreads` returns empty results and a `workspaceDir` was set, re-query with `workspaceDir: undefined` (global scope)
- Add `fallbackToGlobal` flag to `formatThreadPickerIntro` (`src/format.ts`) for an adjusted intro: "No threads in this workspace. Showing recent sessions from all projects."
- Show project names on fallback results since threads span multiple workspaces
- If both workspace and global queries are empty, show the existing "No matching Codex threads found." message
- Add 2 tests for fallback intro text (`src/format.test.ts`)

## Testing

- `pnpm typecheck` passes
- All 127 tests pass (125 existing + 2 new)

Fixes #36

This contribution was developed with AI assistance (Claude Code).