### PR TITLE
Plugin: mask displayed OpenAI account email

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexPlanMarkdownPreview,
+  formatAccountSummary,
   formatBoundThreadSummary,
   formatCodexPlanAttachmentFallback,
   formatCodexPlanAttachmentSummary,
@@ -25,6 +26,7 @@ const TEST_PLUGIN_VERSION = packageJson.version ?? "unknown";
 const TEST_WORKTREE_PATH = "/workspace/.codex/worktrees/41fb/openclaw";
 const TEST_PROJECT_PATH = "/workspace/openclaw";
 const TEST_EMAIL = "user@example.com";
+const TEST_MASKED_EMAIL = "use...@...ple.com";
 
 function shortenHomePathForTest(value: string): string {
   const home = os.homedir();
@@ -151,7 +153,7 @@ describe("formatCodexStatusText", () => {
     expect(text).toContain("Plan mode: off");
     expect(text).toContain("Context usage: unavailable until Codex emits a token-usage update");
     expect(text).toContain("Permissions: Default");
-    expect(text).toContain(`Account: ${TEST_EMAIL} (pro)`);
+    expect(text).toContain(`Account: ${TEST_MASKED_EMAIL} (pro)`);
     expect(text).toContain("Thread: 019cc00d-6cf4-7c11-afcd-2673db349a21");
     expect(text).toContain("Rate limits timezone:");
     expect(text).toContain("5h limit: 85% left");
@@ -472,6 +474,22 @@ describe("formatSkills", () => {
         ],
       }),
     ).toContain("skill-creator - Create or update a Codex skill");
+  });
+});
+
+describe("formatAccountSummary", () => {
+  it("masks account emails in the detailed account summary", () => {
+    const text = formatAccountSummary(
+      {
+        type: "chatgpt",
+        email: TEST_EMAIL,
+        planType: "pro",
+      },
+      [],
+    );
+
+    expect(text).toContain(`Email: ${TEST_MASKED_EMAIL}`);
+    expect(text).not.toContain(`Email: ${TEST_EMAIL}`);
   });
 });
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -50,6 +50,37 @@ function truncateMiddle(value: string, maxLength: number): string {
   return `${value.slice(0, left)}...${value.slice(value.length - right)}`;
 }
 
+function maskEmailPartPrefix(value: string, visibleChars: number): string {
+  const prefix = value.slice(0, Math.min(visibleChars, value.length));
+  return value.length > visibleChars ? `${prefix}...` : prefix;
+}
+
+function maskEmailDomain(value: string): string {
+  const parts = value.split(".").filter(Boolean);
+  if (parts.length === 0) {
+    return value;
+  }
+  const domainNameIndex = Math.max(0, parts.length - 2);
+  const domainName = parts[domainNameIndex] ?? parts[0] ?? "";
+  const publicSuffix =
+    parts.length > 1 ? `.${parts.slice(domainNameIndex + 1).join(".")}` : "";
+  if (domainName.length <= 3) {
+    return `${domainName}${publicSuffix}`;
+  }
+  return `...${domainName.slice(-3)}${publicSuffix}`;
+}
+
+function formatMaskedEmail(email: string): string {
+  const trimmed = email.trim();
+  const atIndex = trimmed.lastIndexOf("@");
+  if (atIndex <= 0 || atIndex >= trimmed.length - 1) {
+    return trimmed;
+  }
+  const localPart = trimmed.slice(0, atIndex);
+  const domainPart = trimmed.slice(atIndex + 1);
+  return `${maskEmailPartPrefix(localPart, 3)}@${maskEmailDomain(domainPart)}`;
+}
+
 function formatThreadButtonTitle(thread: ThreadSummary): string {
   return thread.title?.trim() || thread.threadId;
 }
@@ -283,8 +314,8 @@ export function formatCodexAccountText(account: AccountSummary | null | undefine
   }
   if (account.type === "chatgpt" && account.email?.trim()) {
     return account.planType?.trim()
-      ? `${account.email.trim()} (${account.planType.trim()})`
-      : account.email.trim();
+      ? `${formatMaskedEmail(account.email)} (${account.planType.trim()})`
+      : formatMaskedEmail(account.email);
   }
   if (account.type === "apiKey") {
     return "API key";
@@ -593,7 +624,7 @@ export function formatBoundThreadSummary(params: {
 export function formatAccountSummary(account: AccountSummary, limits: RateLimitSummary[]): string {
   const lines = ["Codex account:"];
   if (account.email) {
-    lines.push(`Email: ${account.email}`);
+    lines.push(`Email: ${formatMaskedEmail(account.email)}`);
   }
   if (account.planType) {
     lines.push(`Plan: ${account.planType}`);


### PR DESCRIPTION
## Summary

I masked displayed OpenAI account emails in the plugin's status and account-summary output.
I added a shared formatter so the redaction stays consistent across both views.
I added tests that verify the masked output for `user@example.com` becomes `use...@...ple.com`.

## Validation

I ran:

- `pnpm test`
- `pnpm typecheck`
