### PR TITLE
Plugin: repaint /cas_status when opening model picker

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -4839,7 +4839,7 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("shows model-picker buttons from the status card callback", async () => {
+  it("shows model-picker buttons in place from the status card callback", async () => {
     const { controller, sendMessageTelegram } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
@@ -4874,22 +4874,29 @@ describe("Discord controller flows", () => {
       },
     } as any);
 
-    expect(editMessage).not.toHaveBeenCalled();
-    const lastCall = sendMessageTelegram.mock.calls.at(-1) as unknown as
-      | [string, string, { buttons?: Array<Array<{ callback_data: string }>> }]
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
+    const lastCall = editMessage.mock.calls.at(-1)?.[0] as
+      | { text?: string; buttons?: Array<Array<{ text: string; callback_data: string }>> }
       | undefined;
-    expect(lastCall?.[1]).toContain("Current model");
-    expect(Array.isArray(lastCall?.[2]?.buttons)).toBe(true);
-    const firstToken = String(lastCall?.[2]?.buttons?.[0]?.[0]?.callback_data ?? "").split(":").pop() ?? "";
+    expect(lastCall?.text).toContain("Binding:");
+    expect(Array.isArray(lastCall?.buttons)).toBe(true);
+    expect(lastCall?.buttons?.some((row) => row[0]?.text === "Cancel")).toBe(true);
+    const firstToken = String(lastCall?.buttons?.[0]?.[0]?.callback_data ?? "").split(":").pop() ?? "";
     expect((controller as any).store.getCallback(firstToken)).toEqual(
       expect.objectContaining({
         kind: "set-model",
         returnToStatus: true,
-        statusMessage: {
-          provider: "telegram",
-          messageId: "41",
-          chatId: "123",
-        },
+      }),
+    );
+    const cancelToken = String(
+      lastCall?.buttons
+        ?.flat()
+        .find((button) => button.text === "Cancel")
+        ?.callback_data ?? "",
+    ).split(":").pop();
+    expect((controller as any).store.getCallback(cancelToken)).toEqual(
+      expect.objectContaining({
+        kind: "refresh-status",
       }),
     );
   });
@@ -5051,90 +5058,6 @@ describe("Discord controller flows", () => {
     expect(pickerCall?.[0]).toBe("123");
     expect(pickerCall?.[1]).toContain("Current model: openai/gpt-5.3");
     expect(pickerCall?.[2]?.buttons?.some((row) => row[0]?.text === "openai/gpt-5.3 (current)")).toBe(true);
-  });
-
-  it("updates the original status message after choosing a model from a separately sent picker", async () => {
-    const { controller, sendMessageTelegram } = await createControllerHarness();
-    const fetchMock = vi.mocked(fetch);
-    await (controller as any).store.upsertBinding({
-      conversation: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "123",
-      },
-      sessionKey: "session-1",
-      threadId: "thread-1",
-      workspaceDir: "/repo/openclaw",
-      updatedAt: Date.now(),
-    });
-    const showPicker = await (controller as any).store.putCallback({
-      kind: "show-model-picker",
-      conversation: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "123",
-      },
-    });
-    const statusEditMessage = vi.fn(async (_payload: any) => {});
-
-    await controller.handleTelegramInteractive({
-      channel: "telegram",
-      accountId: "default",
-      conversationId: "123",
-      callback: {
-        payload: showPicker.token,
-        messageId: 41,
-        chatId: "123",
-      },
-      respond: {
-        clearButtons: vi.fn(async () => {}),
-        reply: vi.fn(async () => {}),
-        editMessage: statusEditMessage,
-      },
-    } as any);
-
-    const pickerCall = sendMessageTelegram.mock.calls.at(-1) as unknown as
-      | [string, string, { buttons?: Array<Array<{ text: string; callback_data: string }>> }]
-      | undefined;
-    const modelCallbackData = pickerCall?.[2]?.buttons?.find((row) => row[0]?.text === "openai/gpt-5.3")?.[0]?.callback_data;
-    const modelToken = modelCallbackData?.split(":").at(-1);
-    expect(modelToken).toBeTruthy();
-    expect(statusEditMessage).not.toHaveBeenCalled();
-
-    const pickerEditMessage = vi.fn(async (_payload: any) => {});
-    await controller.handleTelegramInteractive({
-      channel: "telegram",
-      accountId: "default",
-      conversationId: "123",
-      callback: {
-        payload: modelToken,
-        messageId: 99,
-        chatId: "123",
-      },
-      respond: {
-        clearButtons: vi.fn(async () => {}),
-        reply: vi.fn(async () => {}),
-        editMessage: pickerEditMessage,
-      },
-    } as any);
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.telegram.org/bottelegram-token/editMessageText",
-      expect.objectContaining({
-        method: "POST",
-      }),
-    );
-    expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual(
-      expect.objectContaining({
-        chat_id: "123",
-        message_id: 41,
-        text: expect.stringContaining("Model: openai/gpt-5.3"),
-      }),
-    );
-    expect(pickerEditMessage).toHaveBeenLastCalledWith({
-      text: "Codex model set to openai/gpt-5.3.",
-      buttons: [],
-    });
   });
 
   it("sets the model from the status picker and returns to the updated status card", async () => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1160,11 +1160,14 @@ export class CodexPluginController {
         parentConversationId: ctx.parentConversationId,
         threadId: ctx.threadId,
       },
-      sourceMessage: {
-        provider: "telegram",
-        messageId: String(ctx.callback.messageId),
-        chatId: ctx.callback.chatId,
-      },
+      sourceMessage:
+        ctx.callback.messageId != null && ctx.callback.chatId?.trim()
+          ? {
+              provider: "telegram",
+              messageId: String(ctx.callback.messageId),
+              chatId: ctx.callback.chatId,
+            }
+          : undefined,
       acknowledge: async () => {},
       clear: async () => {
         await ctx.respond.clearButtons().catch(() => undefined);
@@ -2228,6 +2231,18 @@ export class CodexPluginController {
                 : ""
             }`,
           callback_data: `${INTERACTIVE_NAMESPACE}:${callback.token}`,
+        },
+      ]);
+    }
+    if (opts?.returnToStatus) {
+      const cancel = await this.store.putCallback({
+        kind: "refresh-status",
+        conversation,
+      });
+      buttons.push([
+        {
+          text: "Cancel",
+          callback_data: `${INTERACTIVE_NAMESPACE}:${cancel.token}`,
         },
       ]);
     }
@@ -5190,11 +5205,33 @@ export class CodexPluginController {
         await responders.reply("No Codex binding for this conversation.");
         return;
       }
+      const conversation = {
+        ...callback.conversation,
+        threadId: responders.conversation.threadId,
+      };
+      if (responders.sourceMessage) {
+        const [picker, statusCard] = await Promise.all([
+          this.buildModelPicker(
+            conversation,
+            binding,
+            {
+              returnToStatus: true,
+            },
+          ),
+          this.buildStatusCard(
+            conversation,
+            binding,
+            true,
+          ),
+        ]);
+        await responders.editPicker({
+          text: statusCard.text,
+          buttons: picker.buttons,
+        });
+        return;
+      }
       const picker = await this.buildModelPicker(
-        {
-          ...callback.conversation,
-          threadId: responders.conversation.threadId,
-        },
+        conversation,
         binding,
         {
           returnToStatus: true,
@@ -5202,13 +5239,7 @@ export class CodexPluginController {
         },
       );
       await responders.acknowledge?.();
-      await this.sendPickerToConversation(
-        {
-          ...callback.conversation,
-          threadId: responders.conversation.threadId,
-        },
-        picker,
-      );
+      await this.sendPickerToConversation(conversation, picker);
       return;
     }
     if (callback.kind === "set-model") {


### PR DESCRIPTION
## Summary
- I changed the `/cas_status` model button flow to swap the existing status card into model-picker mode instead of sending a separate picker message.
- I added a cancel path so the model picker can repaint the status card cleanly.
- I tightened the Telegram callback handling so we only treat the source message as editable when callback message metadata is actually present.

## Validation
- I ran `pnpm test -- src/controller.test.ts`.
- I ran `pnpm typecheck`.
