### PR TITLE
Fix Telegram callback flows when channel helpers are unavailable

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { existsSync, promises as fs } from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -6836,6 +6837,10 @@ export class CodexPluginController {
           return token;
         }
       }
+      const topLevelToken = typeof telegram?.botToken === "string" ? telegram.botToken.trim() : "";
+      if (topLevelToken) {
+        return topLevelToken;
+      }
       return undefined;
     };
 
@@ -6844,10 +6849,11 @@ export class CodexPluginController {
       return configToken;
     }
 
-    for (const configPath of [
-      "/Volumes/InternalSpareStorage/openclaw/.openclaw/openclaw.json",
-      "/Users/pedrogonzalez/.openclaw/openclaw.json",
-    ]) {
+    const configPaths = new Set<string>([
+      path.join(this.api.runtime.state.resolveStateDir(), "openclaw.json"),
+      path.join(os.homedir(), ".openclaw", "openclaw.json"),
+    ]);
+    for (const configPath of configPaths) {
       try {
         const raw = await fs.readFile(configPath, "utf8");
         const parsed = JSON.parse(raw) as unknown;


### PR DESCRIPTION
## Summary
- preserve runtime config during Telegram interactive callbacks
- guard optional Telegram runtime helpers instead of crashing
- fall back to direct Telegram Bot API sends when `sendMessageTelegram` is unavailable
- allow token resolution to fall back to configured Telegram account bot tokens

## Problem
In Telegram callback / bound-message flows, the plugin can bind successfully and then fail before replying because some OpenClaw builds do not expose the expected `api.runtime.channel.telegram.*` helpers in that context.

Observed failures included:
- `Cannot read properties of undefined (reading 'typing')`
- `Cannot read properties of undefined (reading 'sendMessageTelegram')`
- `Cannot read properties of undefined (reading 'resolveTelegramToken')`
- `Telegram send unavailable`

## Fix
- Persist callback runtime config in `handleTelegramInteractive()`
- Treat typing/topic rename as optional when Telegram runtime helpers are absent
- Use runtime Telegram sender when available, otherwise send via Telegram Bot API using resolved config token
- Add config fallback for `channels.telegram.accounts[accountId].botToken`

## Validation
- `npm run typecheck`
- `npm test`

Closes/references: #69
