### PR TITLE
Add Telegram runtime compatibility fallbacks for OpenClaw 2026.3.31

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -347,6 +347,56 @@ describe("Telegram runtime compatibility fallbacks", () => {
     });
   });
 
+  it("reads the Telegram token from openclaw.json when runtime config is unavailable", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+      json: async () => ({
+        ok: true,
+        result: {
+          message_id: 43,
+          chat: { id: 123 },
+        },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { controller, api, stateDir } = await createControllerHarness();
+    delete (api as any).runtime.channel.telegram;
+    (controller as any).lastRuntimeConfig = undefined;
+    fs.writeFileSync(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: "telegram-file-token",
+          },
+        },
+      }),
+    );
+
+    const delivered = await (controller as any).sendTextWithDeliveryRef(
+      {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "123",
+      },
+      "hello from config-file fallback",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottelegram-file-token/sendMessage",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(delivered).toEqual({
+      provider: "telegram",
+      messageId: "43",
+      chatId: "123",
+    });
+  });
+
   it("falls back to sendChatAction typing when channel.telegram is unavailable", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { existsSync, promises as fs } from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -6811,7 +6812,18 @@ export class CodexPluginController {
     if (runtimeToken) {
       return runtimeToken;
     }
-    const cfg = asRecord(this.lastRuntimeConfig);
+    const configToken = this.extractTelegramBotTokenFromConfig(this.lastRuntimeConfig, accountId);
+    if (configToken) {
+      return configToken;
+    }
+    return await this.resolveTelegramBotTokenFromConfigFile(accountId);
+  }
+
+  private extractTelegramBotTokenFromConfig(
+    config: unknown,
+    accountId?: string,
+  ): string | undefined {
+    const cfg = asRecord(config);
     const channels = asRecord(cfg?.channels);
     const telegram = asRecord(channels?.telegram);
     const directToken = typeof telegram?.botToken === "string" ? telegram.botToken.trim() : "";
@@ -6819,16 +6831,67 @@ export class CodexPluginController {
       return directToken;
     }
     const accounts = asRecord(telegram?.accounts);
-    if (accountId && accounts) {
-      const account = asRecord(accounts[accountId]);
-      const accountToken =
-        typeof account?.botToken === "string"
-          ? account.botToken.trim()
-          : typeof account?.token === "string"
-            ? account.token.trim()
-            : "";
-      if (accountToken) {
-        return accountToken;
+    if (!accountId || !accounts) {
+      return undefined;
+    }
+    const account = asRecord(accounts[accountId]);
+    const accountToken =
+      typeof account?.botToken === "string"
+        ? account.botToken.trim()
+        : typeof account?.token === "string"
+          ? account.token.trim()
+          : "";
+    return accountToken || undefined;
+  }
+
+  private resolveOpenClawConfigCandidatePaths(): string[] {
+    const candidates = new Set<string>();
+    const addCandidate = (candidate?: string | null): void => {
+      const normalized = candidate ? expandHomeDir(candidate.trim()) : "";
+      if (!normalized) {
+        return;
+      }
+      candidates.add(path.resolve(normalized));
+    };
+    addCandidate(process.env.OPENCLAW_CONFIG_PATH);
+    const configDir = process.env.OPENCLAW_CONFIG_DIR?.trim();
+    if (configDir) {
+      addCandidate(path.join(configDir, "openclaw.json"));
+    }
+    const stateDir = this.api.runtime.state.resolveStateDir();
+    if (stateDir?.trim()) {
+      let current = path.resolve(stateDir);
+      while (true) {
+        addCandidate(path.join(current, "openclaw.json"));
+        const parent = path.dirname(current);
+        if (parent === current) {
+          break;
+        }
+        current = parent;
+      }
+    }
+    addCandidate(path.join(os.homedir(), ".openclaw", "openclaw.json"));
+    return [...candidates];
+  }
+
+  private async resolveTelegramBotTokenFromConfigFile(
+    accountId?: string,
+  ): Promise<string | undefined> {
+    for (const configPath of this.resolveOpenClawConfigCandidatePaths()) {
+      if (!existsSync(configPath)) {
+        continue;
+      }
+      try {
+        const raw = await fs.readFile(configPath, "utf8");
+        const parsed = JSON.parse(raw) as unknown;
+        const token = this.extractTelegramBotTokenFromConfig(parsed, accountId);
+        if (token) {
+          return token;
+        }
+      } catch (error) {
+        this.api.logger.debug?.(
+          `codex telegram token fallback config read failed path=${configPath}: ${String(error)}`,
+        );
       }
     }
     return undefined;


### PR DESCRIPTION
## Summary
- add Telegram compatibility fallbacks when `api.runtime.channel.telegram` is unavailable on newer OpenClaw builds
- route outbound Telegram sends through a compat helper that falls back to Bot API `sendMessage` / `sendDocument`
- fall back to Bot API `sendChatAction`, config-based token resolution, and `editForumTopic` for typing/topic rename
- add regression tests covering send, typing, and topic-rename fallback behavior

## Validation
- `pnpm typecheck`
- `pnpm test`

Fixes #69.