### PR TITLE
Plugin: restore Discord sdk compatibility fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Compatibility:
 
 | Plugin release | OpenClaw compatibility |
 | --- | --- |
-| `0.6.0+` | `2026.3.22` and newer, with automatic fallback between the legacy Telegram runtime shim and the `2026.3.31+` outbound adapter facade |
+| `0.6.1+` | `2026.3.22` and newer, including post-`v2026.4.2` local checkouts such as `2026.4.5`, with fallback across the legacy Telegram runtime shim, the `2026.3.31+` outbound adapter, and the generated Discord / Telegram facades used after the channel-specific SDK exports were removed |
+| `0.6.0` | `2026.3.22` through `v2026.4.2`; falls back between the legacy Telegram runtime shim and the `2026.3.31+` outbound adapter, but newer local OpenClaw checkouts break Discord interactive loading because `openclaw/plugin-sdk/discord` is no longer exported |
 | `0.5.x` | `2026.3.22` through `2026.3.30`; Telegram breaks on `2026.3.31+` |
 
 Install:
@@ -50,7 +51,7 @@ Uninstall:
 openclaw plugins uninstall openclaw-codex-app-server
 ```
 
-OpenClaw `2026.3.22` and newer include the binding and plugin interface changes this package originally targeted. Plugin `0.6.0+` prefers the newer OpenClaw `2026.3.31+` outbound adapter and Telegram account facade when they are present, but it also falls back to the older `runtime.channel.telegram` interface used by OpenClaw `2026.3.22` through `2026.3.30`. Older plugin `0.5.x` releases only match that legacy path and are not compatible with Telegram on OpenClaw `2026.3.31+`.
+OpenClaw `2026.3.22` and newer include the binding and plugin interface changes this package originally targeted. Plugin `0.6.1+` first tries the public `openclaw/plugin-sdk/discord` and `openclaw/plugin-sdk/telegram-account` paths that existed through released OpenClaw `v2026.4.2`, then falls back to the generated `dist/plugin-sdk/*.js` facades used by newer local checkouts such as `2026.4.5`, while still preserving the older `runtime.channel.telegram` path used by OpenClaw `2026.3.22` through `2026.3.30`. Plugin `0.6.0` covers the Telegram runtime and outbound-adapter split, but not the later Discord facade export removal. Older plugin `0.5.x` releases only match the legacy Telegram path and are not compatible with Telegram on OpenClaw `2026.3.31+`.
 
 > ⚠️ OpenClaw flags this plugin as unsafe because it must launch `codex app-server`. That process spawn is the whole bridge, not an optional extra.
 

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -467,6 +467,10 @@ async function createControllerHarnessWithoutDiscordSendSurfaces() {
         updatedAt: Date.now() - 30_000,
       },
     ]),
+    listSkills: vi.fn(async () => [
+      { name: "skill-a", description: "Skill A", cwd: "/repo/openclaw" },
+      { name: "skill-b", description: "Skill B", cwd: "/repo/openclaw" },
+    ]),
     readThreadState: vi.fn(async () => ({
       threadId: "thread-1",
       threadName: "Discord Thread",
@@ -1227,6 +1231,33 @@ describe("Discord controller flows", () => {
             ]),
           }),
         ]),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
+  it("sends Discord skills through the runtime api when adapter and legacy runtime are absent", async () => {
+    const { controller } = await createControllerHarnessWithoutDiscordSendSurfaces();
+    const sendDiscordComponentMessage = vi.fn(async () => ({
+      messageId: "discord-component-1",
+      channelId: "channel:chan-1",
+    }));
+    vi.spyOn(controller as any, "loadDiscordRuntimeApi").mockResolvedValue({
+      sendDiscordComponentMessage,
+    });
+
+    const reply = await controller.handleCommand("cas_skills", buildDiscordCommandContext({
+      commandBody: "/cas_skills",
+    }));
+
+    expect(reply).toEqual({
+      text: "Sent Codex skills to this Discord conversation.",
+    });
+    expect(sendDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel:chan-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Type `$skill-name` in this chat to run one directly."),
+        blocks: expect.any(Array),
       }),
       expect.objectContaining({ accountId: "default" }),
     );
@@ -2686,6 +2717,28 @@ describe("Discord controller flows", () => {
         }),
       }),
     );
+  });
+
+  it("resolves the Discord bot token through the host api when the sdk facade is unavailable", async () => {
+    const { controller } = await createControllerHarness();
+    (controller as any).lastRuntimeConfig = { plugins: { discord: {} } };
+    vi.spyOn(controller as any, "loadDiscordSdk").mockRejectedValue(
+      new Error(
+        "Cannot find module '/Users/huntharo/github/openclaw/dist/plugin-sdk/root-alias.cjs/discord'",
+      ),
+    );
+    const resolveDiscordAccount = vi.fn(() => ({ token: "discord-token" }));
+    vi.spyOn(controller as any, "loadDiscordExtensionApi").mockResolvedValue({
+      resolveDiscordAccount,
+    });
+
+    const token = await (controller as any).resolveDiscordBotToken("default");
+
+    expect(token).toBe("discord-token");
+    expect(resolveDiscordAccount).toHaveBeenCalledWith({
+      cfg: { plugins: { discord: {} } },
+      accountId: "default",
+    });
   });
 
   it("replays pending cas_resume --sync effects after approval hydrates on the next resume command", async () => {
@@ -5112,6 +5165,7 @@ describe("Discord controller flows", () => {
       reason: "inbound",
     });
 
+    await flushAsyncWork();
     await flushAsyncWork();
     expect(sendMessageTelegram).toHaveBeenCalledWith(
       TEST_TELEGRAM_PEER_ID,

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -449,6 +449,49 @@ async function createControllerHarnessWithoutLegacyDiscordRuntime() {
   };
 }
 
+async function createControllerHarnessWithoutDiscordSendSurfaces() {
+  const harness = createApiMock();
+  delete (harness.api as any).runtime.channel.discord;
+  (harness.api as any).runtime.channel.outbound.loadAdapter = vi.fn(async (channel: string) =>
+    channel === "telegram" ? harness.telegramOutbound : undefined,
+  );
+  const controller = new CodexPluginController(harness.api);
+  await controller.start();
+  const clientMock = {
+    listThreads: vi.fn(async () => [
+      {
+        threadId: "thread-1",
+        title: "Discord Thread",
+        projectKey: "/repo/openclaw",
+        createdAt: Date.now() - 60_000,
+        updatedAt: Date.now() - 30_000,
+      },
+    ]),
+    readThreadState: vi.fn(async () => ({
+      threadId: "thread-1",
+      threadName: "Discord Thread",
+      model: "openai/gpt-5.4",
+      cwd: "/repo/openclaw",
+      serviceTier: "default",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+    })),
+    readThreadContext: vi.fn(async () => ({
+      lastUserMessage: undefined,
+      lastAssistantMessage: undefined,
+    })),
+    readAccount: vi.fn(async () => ({
+      email: "test@example.com",
+      planType: "pro",
+      type: "chatgpt",
+    })),
+    readRateLimits: vi.fn(async () => []),
+  };
+  (controller as any).client = clientMock;
+  (controller as any).readThreadHasChanges = vi.fn(async () => false);
+  return { controller };
+}
+
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version?: string };
 const TEST_PLUGIN_VERSION = packageJson.version ?? "unknown";
@@ -602,6 +645,33 @@ describe("Discord controller flows", () => {
             }),
           }),
         }),
+      }),
+    );
+  });
+
+  it("sends resume pickers through the Discord runtime api when adapter and legacy runtime are absent", async () => {
+    const { controller } = await createControllerHarnessWithoutDiscordSendSurfaces();
+    const sendDiscordComponentMessage = vi.fn(async () => ({
+      messageId: "discord-component-1",
+      channelId: "channel:chan-1",
+    }));
+    vi.spyOn(controller as any, "loadDiscordRuntimeApi").mockResolvedValue({
+      sendDiscordComponentMessage,
+    });
+
+    const reply = await controller.handleCommand("cas_resume", buildDiscordCommandContext());
+
+    expect(reply).toEqual({
+      text: "Sent a Codex thread picker to this Discord conversation.",
+    });
+    expect(sendDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel:chan-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Showing recent Codex threads"),
+        blocks: expect.any(Array),
+      }),
+      expect.objectContaining({
+        accountId: "default",
       }),
     );
   });

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -1203,6 +1203,91 @@ describe("Discord controller flows", () => {
     );
   });
 
+  it("prefers the Discord channel target over a user target for cas_status binding lookups", async () => {
+    const { controller, sendComponentMessage } = await createControllerHarness();
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    });
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildDiscordCommandContext({
+        from: "discord:user-1",
+        to: "discord:channel:chan-1",
+        commandBody: "/cas_status",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
+      }),
+    );
+
+    expect(reply).toEqual({
+      text: "Sent Codex status controls to this Discord conversation.",
+    });
+    expect(sendComponentMessage).toHaveBeenCalledWith(
+      "channel:chan-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Binding: Discord Thread (openclaw)"),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
+  it("uses the Discord thread target for cas_status binding lookups when slash commands run in a thread", async () => {
+    const { controller, sendComponentMessage } = await createControllerHarness();
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    });
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildDiscordCommandContext({
+        from: "discord:channel:parent-1",
+        to: "slash:user-1",
+        messageThreadId: "thread-1",
+        threadParentId: "parent-1",
+        commandBody: "/cas_status",
+        getCurrentConversationBinding: vi.fn(async () => ({
+          bindingId: "b1",
+          pluginId: "test-plugin",
+          pluginRoot: "/repo/openclaw-app-server",
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel:thread-1",
+          parentConversationId: "channel:parent-1",
+          threadId: "thread-1",
+          boundAt: Date.now(),
+        })),
+      }),
+    );
+
+    expect(reply).toEqual({
+      text: "Sent Codex status controls to this Discord conversation.",
+    });
+    expect(sendComponentMessage).toHaveBeenCalledWith(
+      "channel:thread-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Binding: Discord Thread (openclaw)"),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
   it("sends Discord skills directly instead of returning Telegram buttons", async () => {
     const { controller, sendComponentMessage } = await createControllerHarness();
 
@@ -1464,7 +1549,7 @@ describe("Discord controller flows", () => {
   });
 
   it("falls back to direct Discord message edit when Discord picker rebuild is unavailable", async () => {
-    const { controller, sendComponentMessage } = await createControllerHarness();
+    const { controller, sendComponentMessage, api } = await createControllerHarness();
     const callback = await (controller as any).store.putCallback({
       kind: "picker-view",
       conversation: {
@@ -1528,6 +1613,7 @@ describe("Discord controller flows", () => {
       }),
       expect.objectContaining({ accountId: "default" }),
     );
+    expect((api.logger.warn as any).mock.calls).toEqual([]);
     expect(discordSdkState.registerBuiltDiscordComponentMessage).not.toHaveBeenCalled();
     expect(sendComponentMessage).not.toHaveBeenCalled();
   });
@@ -1982,8 +2068,8 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("shows cas_status as none when no core binding exists", async () => {
-    const { controller } = await createControllerHarness();
+  it("shows cas_status from the persisted local binding when core lookup is unavailable", async () => {
+    const { controller, sendComponentMessage } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
       conversation: {
         channel: "discord",
@@ -2007,10 +2093,23 @@ describe("Discord controller flows", () => {
       }),
     );
 
-    expect(reply.text).toContain("Binding: none");
-    expect(reply.text).toContain(`Plugin version: ${TEST_PLUGIN_VERSION}`);
-    expect(reply.text).not.toContain("Project folder: /repo/discrawl");
-    expect(reply.text).not.toContain("Session: session-1");
+    expect(reply).toEqual({
+      text: "Sent Codex status controls to this Discord conversation.",
+    });
+    expect(sendComponentMessage).toHaveBeenCalledWith(
+      "user:1177378744822943744",
+      expect.objectContaining({
+        text: expect.stringContaining("Binding: Discord Thread (discrawl)"),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(sendComponentMessage).toHaveBeenCalledWith(
+      "user:1177378744822943744",
+      expect.objectContaining({
+        text: expect.stringContaining("Project folder: /repo/discrawl"),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
   });
 
   it("does not hydrate a denied pending bind into cas_status", async () => {
@@ -4520,6 +4619,30 @@ describe("Discord controller flows", () => {
         mediaLocalRoots: expect.arrayContaining([stateDir, path.dirname(attachmentPath)]),
       }),
     );
+  });
+
+  it("does not forward Discord thread ids into outbound adapter sends", async () => {
+    const { controller, discordOutbound } = await createControllerHarnessWithoutLegacyDiscordRuntime();
+
+    const sent = await (controller as any).sendReply(
+      {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1485612939816996956",
+        threadId: 1485612939816996900,
+      },
+      {
+        text: "hello from a bound discord thread",
+      },
+    );
+
+    expect(sent).toBe(true);
+    const outboundCall = discordOutbound.sendText.mock.calls.at(-1)?.[0] as
+      | { to?: string; accountId?: string; threadId?: unknown }
+      | undefined;
+    expect(outboundCall?.to).toBe("channel:1485612939816996956");
+    expect(outboundCall?.accountId).toBe("default");
+    expect("threadId" in (outboundCall ?? {})).toBe(false);
   });
 
   it("restarts a Discord bound run when the active queue path fails", async () => {

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -51,6 +51,39 @@ function createApiMock() {
   const renameTopic = vi.fn(async () => ({}));
   const resolveTelegramToken = vi.fn(() => ({ token: "telegram-token", source: "config" }));
   const editChannel = vi.fn(async () => ({}));
+  const discordOutbound = {
+    sendText: vi.fn(
+      async (ctx: { to: string; text: string; accountId?: string; threadId?: string | number }) => ({
+        messageId: "discord-msg-1",
+        channelId: ctx.to,
+      }),
+    ),
+    sendMedia: vi.fn(
+      async (ctx: {
+        to: string;
+        text: string;
+        mediaUrl: string;
+        accountId?: string;
+        threadId?: string | number;
+        mediaLocalRoots?: readonly string[];
+      }) => ({
+        messageId: "discord-msg-1",
+        channelId: ctx.to,
+      }),
+    ),
+    sendPayload: vi.fn(
+      async (ctx: {
+        to: string;
+        payload: ReplyPayload;
+        accountId?: string;
+        threadId?: string | number;
+        mediaLocalRoots?: readonly string[];
+      }) => ({
+        messageId: "discord-component-1",
+        channelId: ctx.to,
+      }),
+    ),
+  };
   const telegramOutbound = {
     sendText: vi.fn(async (ctx: { to: string; text: string; accountId?: string; threadId?: string | number }) =>
       await sendMessageTelegram(ctx.to, ctx.text, {
@@ -121,7 +154,13 @@ function createApiMock() {
             opts?.fallbackLimit ?? 2000,
         },
         outbound: {
-          loadAdapter: vi.fn(async (channel: string) => (channel === "telegram" ? telegramOutbound : undefined)),
+          loadAdapter: vi.fn(async (channel: string) =>
+            channel === "telegram"
+              ? telegramOutbound
+              : channel === "discord"
+                ? undefined
+                : undefined,
+          ),
         },
         telegram: {
           sendMessageTelegram,
@@ -161,6 +200,7 @@ function createApiMock() {
     renameTopic,
     resolveTelegramToken,
     editChannel,
+    discordOutbound,
     stateDir,
   };
 }
@@ -175,6 +215,7 @@ async function createControllerHarness() {
     renameTopic,
     resolveTelegramToken,
     editChannel,
+    discordOutbound,
     stateDir,
   } = createApiMock();
   const controller = new CodexPluginController(api);
@@ -266,6 +307,7 @@ async function createControllerHarness() {
     renameTopic,
     resolveTelegramToken,
     editChannel,
+    discordOutbound,
     stateDir,
   };
 }
@@ -354,6 +396,56 @@ async function createControllerHarnessWithoutTelegramPayloadSupport() {
     controller,
     api: harness.api,
     sendMessageTelegram: harness.sendMessageTelegram,
+  };
+}
+
+async function createControllerHarnessWithoutLegacyDiscordRuntime() {
+  const harness = createApiMock();
+  delete (harness.api as any).runtime.channel.discord;
+  (harness.api as any).runtime.channel.outbound.loadAdapter = vi.fn(async (channel: string) =>
+    channel === "telegram"
+      ? harness.telegramOutbound
+      : channel === "discord"
+        ? harness.discordOutbound
+        : undefined,
+  );
+  const controller = new CodexPluginController(harness.api);
+  await controller.start();
+  const clientMock = {
+    listThreads: vi.fn(async () => [
+      {
+        threadId: "thread-1",
+        title: "Discord Thread",
+        projectKey: "/repo/openclaw",
+        createdAt: Date.now() - 60_000,
+        updatedAt: Date.now() - 30_000,
+      },
+    ]),
+    readThreadState: vi.fn(async () => ({
+      threadId: "thread-1",
+      threadName: "Discord Thread",
+      model: "openai/gpt-5.4",
+      cwd: "/repo/openclaw",
+      serviceTier: "default",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+    })),
+    readThreadContext: vi.fn(async () => ({
+      lastUserMessage: undefined,
+      lastAssistantMessage: undefined,
+    })),
+    readAccount: vi.fn(async () => ({
+      email: "test@example.com",
+      planType: "pro",
+      type: "chatgpt",
+    })),
+    readRateLimits: vi.fn(async () => []),
+  };
+  (controller as any).client = clientMock;
+  (controller as any).readThreadHasChanges = vi.fn(async () => false);
+  return {
+    controller,
+    discordOutbound: harness.discordOutbound,
   };
 }
 
@@ -484,6 +576,32 @@ describe("Discord controller flows", () => {
       }),
       expect.objectContaining({
         accountId: "default",
+      }),
+    );
+  });
+
+  it("sends resume pickers through the Discord outbound adapter when the legacy runtime is absent", async () => {
+    const { controller, discordOutbound } = await createControllerHarnessWithoutLegacyDiscordRuntime();
+
+    const reply = await controller.handleCommand("cas_resume", buildDiscordCommandContext());
+
+    expect(reply).toEqual({
+      text: "Sent a Codex thread picker to this Discord conversation.",
+    });
+    expect(discordOutbound.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "channel:chan-1",
+        accountId: "default",
+        payload: expect.objectContaining({
+          text: expect.stringContaining("Showing recent Codex threads"),
+          channelData: expect.objectContaining({
+            discord: expect.objectContaining({
+              components: expect.objectContaining({
+                blocks: expect.any(Array),
+              }),
+            }),
+          }),
+        }),
       }),
     );
   });

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -1432,6 +1432,75 @@ describe("Discord controller flows", () => {
     expect(sendComponentMessage).not.toHaveBeenCalled();
   });
 
+  it("falls back to direct Discord message edit when Discord picker rebuild is unavailable", async () => {
+    const { controller, sendComponentMessage } = await createControllerHarness();
+    const callback = await (controller as any).store.putCallback({
+      kind: "picker-view",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:chan-1",
+      },
+      view: {
+        mode: "projects",
+        includeAll: true,
+        page: 0,
+      },
+    });
+    const acknowledge = vi.fn(async () => {});
+    const editMessage = vi.fn(async () => {});
+    const runtimeEdit = vi.fn(async () => ({
+      messageId: "message-1",
+      channelId: "channel:chan-1",
+    }));
+    vi.spyOn(controller as any, "tryBuildDiscordPickerMessage").mockResolvedValue(undefined);
+    vi.spyOn(controller as any, "loadDiscordSdk").mockRejectedValue(
+      new Error(
+        "Cannot find module '/Users/huntharo/github/openclaw/dist/plugin-sdk/root-alias.cjs/discord'",
+      ),
+    );
+    vi.spyOn(controller as any, "loadDiscordRuntimeApi").mockResolvedValue({
+      editDiscordComponentMessage: runtimeEdit,
+    });
+
+    await controller.handleDiscordInteractive({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "interaction-1",
+      conversationId: "channel:chan-1",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "button",
+        data: `codexapp:${callback.token}`,
+        namespace: "codexapp",
+        payload: callback.token,
+        messageId: "message-1",
+      },
+      senderId: "user-1",
+      senderUsername: "Ada",
+      respond: {
+        acknowledge,
+        reply: vi.fn(async () => {}),
+        followUp: vi.fn(async () => {}),
+        editMessage,
+        clearComponents: vi.fn(async () => {}),
+      },
+    } as any);
+
+    expect(editMessage).not.toHaveBeenCalled();
+    expect(acknowledge).toHaveBeenCalled();
+    expect(runtimeEdit).toHaveBeenCalledWith(
+      "channel:chan-1",
+      "message-1",
+      expect.objectContaining({
+        text: expect.stringContaining("Choose a project to filter recent Codex threads"),
+      }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(discordSdkState.registerBuiltDiscordComponentMessage).not.toHaveBeenCalled();
+    expect(sendComponentMessage).not.toHaveBeenCalled();
+  });
+
   it("acknowledges and clears Discord pending-input buttons by message id", async () => {
     const { controller } = await createControllerHarness();
     await (controller as any).store.upsertPendingRequest({

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,13 +16,6 @@ import type {
   ReplyPayload,
   ConversationRef,
 } from "openclaw/plugin-sdk";
-import {
-  buildDiscordComponentMessage,
-  editDiscordComponentMessage,
-  registerBuiltDiscordComponentMessage,
-  type DiscordComponentMessageSpec,
-  resolveDiscordAccount,
-} from "openclaw/plugin-sdk/discord";
 import { resolvePluginSettings, resolveWorkspaceDir } from "./config.js";
 import { CodexAppServerModeClient, type ActiveCodexRun, isMissingThreadError } from "./client.js";
 import { getThreadDisplayTitle } from "./thread-display.js";
@@ -101,6 +94,12 @@ import {
   type StoredPendingBind,
   type StoredPendingRequest,
 } from "./types.js";
+import { loadOpenClawCompatModule } from "./openclaw-sdk-compat.js";
+
+type DiscordSdkModule = typeof import("openclaw/plugin-sdk/discord");
+type TelegramAccountSdkModule = typeof import("openclaw/plugin-sdk/telegram-account");
+type DiscordComponentMessageSpec = import("openclaw/plugin-sdk/discord").DiscordComponentMessageSpec;
+type DiscordComponentBuildResult = ReturnType<DiscordSdkModule["buildDiscordComponentMessage"]>;
 
 type ActiveRunRecord = {
   conversation: ConversationTarget;
@@ -1571,7 +1570,7 @@ export class CodexPluginController {
               callback.kind === "pending-questionnaire"
                 ? "Recorded your answers and sent them to Codex."
                 : "Sent to Codex.";
-            await editDiscordComponentMessage(
+            await this.editDiscordComponentMessage(
               conversation.conversationId,
               messageId,
               {
@@ -1612,14 +1611,14 @@ export class CodexPluginController {
             `codex discord picker refresh conversation=${conversationId} rows=${picker.buttons?.length ?? 0}`,
           );
           const messageId = ctx.interaction.messageId?.trim();
-          const builtPicker = this.buildDiscordPickerMessage(picker);
+          const builtPicker = await this.buildDiscordPickerMessage(picker);
           try {
             await ctx.respond.editMessage({
               components: builtPicker.components,
             });
             interactionSettled = true;
             if (messageId) {
-              registerBuiltDiscordComponentMessage({
+              await this.registerBuiltDiscordComponentMessage({
                 buildResult: builtPicker,
                 messageId,
               });
@@ -1639,7 +1638,7 @@ export class CodexPluginController {
                   })
                   .catch(() => undefined);
               }
-              await editDiscordComponentMessage(
+              await this.editDiscordComponentMessage(
                 conversation.conversationId,
                 messageId,
                 this.buildDiscordPickerSpec(picker),
@@ -1666,7 +1665,7 @@ export class CodexPluginController {
             });
             const originalMessageId = ctx.interaction.messageId?.trim();
             if (callback.kind === "resume-thread" && originalMessageId) {
-              await editDiscordComponentMessage(
+              await this.editDiscordComponentMessage(
                 conversation.conversationId,
                 originalMessageId,
                 {
@@ -2464,11 +2463,11 @@ export class CodexPluginController {
         });
         return true;
       }
-      const builtPicker = this.buildDiscordPickerMessage({
+      const builtPicker = await this.buildDiscordPickerMessage({
         text: statusCard.text,
         buttons: statusCard.buttons,
       });
-      await editDiscordComponentMessage(
+      await this.editDiscordComponentMessage(
         message.channelId,
         message.messageId,
         this.buildDiscordPickerSpec({
@@ -2479,7 +2478,7 @@ export class CodexPluginController {
           accountId: conversation.accountId,
         },
       );
-      registerBuiltDiscordComponentMessage({
+      await this.registerBuiltDiscordComponentMessage({
         buildResult: builtPicker,
         messageId: message.messageId,
       });
@@ -4842,10 +4841,49 @@ export class CodexPluginController {
     };
   }
 
-  private buildDiscordPickerMessage(picker: PickerRender) {
-    return buildDiscordComponentMessage({
+  private async buildDiscordPickerMessage(
+    picker: PickerRender,
+  ): Promise<DiscordComponentBuildResult> {
+    const discordSdk = await this.loadDiscordSdk();
+    return discordSdk.buildDiscordComponentMessage({
       spec: this.buildDiscordPickerSpec(picker),
     });
+  }
+
+  private async loadDiscordSdk(): Promise<DiscordSdkModule> {
+    return await loadOpenClawCompatModule<DiscordSdkModule>({
+      specifier: "openclaw/plugin-sdk/discord",
+      fallbackRelativePath: "dist/plugin-sdk/discord.js",
+      label: "discord",
+      logger: this.api.logger,
+    });
+  }
+
+  private async loadTelegramAccountSdk(): Promise<TelegramAccountSdkModule> {
+    return await loadOpenClawCompatModule<TelegramAccountSdkModule>({
+      specifier: "openclaw/plugin-sdk/telegram-account",
+      fallbackRelativePath: "dist/plugin-sdk/telegram-account.js",
+      label: "telegram account",
+      logger: this.api.logger,
+    });
+  }
+
+  private async editDiscordComponentMessage(
+    to: string,
+    messageId: string,
+    spec: DiscordComponentMessageSpec,
+    opts?: { accountId?: string },
+  ): Promise<{ messageId: string; channelId: string }> {
+    const discordSdk = await this.loadDiscordSdk();
+    return await discordSdk.editDiscordComponentMessage(to, messageId, spec, opts);
+  }
+
+  private async registerBuiltDiscordComponentMessage(params: {
+    buildResult: DiscordComponentBuildResult;
+    messageId: string;
+  }): Promise<void> {
+    const discordSdk = await this.loadDiscordSdk();
+    discordSdk.registerBuiltDiscordComponentMessage(params);
   }
 
   private async dispatchCallbackAction(
@@ -6971,7 +7009,7 @@ export class CodexPluginController {
       return undefined;
     }
     try {
-      const telegramAccount = await import("openclaw/plugin-sdk/telegram-account");
+      const telegramAccount = await this.loadTelegramAccountSdk();
       const account = telegramAccount.resolveTelegramAccount({
         cfg,
         accountId,
@@ -6989,8 +7027,9 @@ export class CodexPluginController {
     if (!cfg) {
       return undefined;
     }
-    const account = resolveDiscordAccount({
-      cfg: cfg as Parameters<typeof resolveDiscordAccount>[0]["cfg"],
+    const discordSdk = await this.loadDiscordSdk();
+    const account = discordSdk.resolveDiscordAccount({
+      cfg: cfg as Parameters<DiscordSdkModule["resolveDiscordAccount"]>[0]["cfg"],
       accountId,
     });
     const token = account.token?.trim();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -95,6 +95,7 @@ import {
   type StoredPendingRequest,
 } from "./types.js";
 import {
+  isMissingPluginSdkSubpathError,
   loadOpenClawCompatModule,
   resolveOpenClawEntrypointPath,
   resolveCompatFallbackPath,
@@ -466,6 +467,77 @@ function normalizeDiscordInteractiveConversationId(params: {
   return params.guildId ? `channel:${normalized}` : `user:${normalized}`;
 }
 
+function readCommandContextId(ctx: PluginCommandContext, key: string): string | undefined {
+  const value = asRecord(ctx)?.[key];
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value));
+  }
+  return undefined;
+}
+
+function normalizeDiscordChannelConversationId(raw?: string): string | undefined {
+  const normalized = normalizeDiscordConversationId(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.includes(":") ? normalized : `channel:${normalized}`;
+}
+
+function resolveDiscordCommandConversation(
+  ctx: PluginCommandContext,
+): ConversationTarget | null {
+  const threadConversationId = normalizeDiscordChannelConversationId(
+    readCommandContextId(ctx, "messageThreadId"),
+  );
+  if (threadConversationId) {
+    return {
+      channel: "discord",
+      accountId: ctx.accountId ?? "default",
+      conversationId: threadConversationId,
+      parentConversationId: normalizeDiscordChannelConversationId(
+        readCommandContextId(ctx, "threadParentId"),
+      ),
+    };
+  }
+  const candidates = [ctx.from, ctx.to]
+    .map((raw) => {
+      const normalized = normalizeDiscordConversationId(raw);
+      if (!normalized) {
+        return undefined;
+      }
+      const kind = normalized.startsWith("channel:")
+        ? 2
+        : normalized.startsWith("user:")
+          ? 1
+          : 0;
+      return {
+        raw: raw?.trim() ?? "",
+        normalized,
+        kind,
+      };
+    })
+    .filter((candidate): candidate is { raw: string; normalized: string; kind: number } =>
+      Boolean(candidate),
+    );
+  if (candidates.length === 0) {
+    return null;
+  }
+  candidates.sort((left, right) => right.kind - left.kind);
+  const conversationId = candidates[0]?.normalized;
+  if (!conversationId) {
+    return null;
+  }
+  return {
+    channel: "discord",
+    accountId: ctx.accountId ?? "default",
+    conversationId,
+  };
+}
+
 function toConversationTargetFromCommand(ctx: PluginCommandContext): ConversationTarget | null {
   if (isTelegramChannel(ctx.channel)) {
     const chatId = normalizeTelegramChatId(ctx.to ?? ctx.from ?? ctx.senderId);
@@ -478,24 +550,11 @@ function toConversationTargetFromCommand(ctx: PluginCommandContext): Conversatio
       conversationId:
         typeof ctx.messageThreadId === "number" ? `${chatId}:topic:${ctx.messageThreadId}` : chatId,
       parentConversationId: typeof ctx.messageThreadId === "number" ? chatId : undefined,
-      threadId: ctx.messageThreadId,
+      threadId: typeof ctx.messageThreadId === "number" ? ctx.messageThreadId : undefined,
     };
   }
   if (isDiscordChannel(ctx.channel)) {
-    // In brand-new Discord threads, the slash interaction may place the slash
-    // user identity in ctx.from (e.g. "slash:user-id") while ctx.to holds the
-    // real channel target. Prefer ctx.to when ctx.from is a slash identity so
-    // /cas_resume resolves to the correct channel from the first attempt.
-    const sourceId = ctx.from?.startsWith("slash:") ? ctx.to : (ctx.from ?? ctx.to);
-    const conversationId = normalizeDiscordConversationId(sourceId);
-    if (!conversationId) {
-      return null;
-    }
-    return {
-      channel: "discord",
-      accountId: ctx.accountId ?? "default",
-      conversationId,
-    };
+    return resolveDiscordCommandConversation(ctx);
   }
   return null;
 }
@@ -543,13 +602,15 @@ function toConversationTargetFromInbound(event: {
     conversationId,
     parentConversationId,
     threadId:
-      typeof event.threadId === "number"
-        ? event.threadId
-        : typeof event.threadId === "string"
-          ? Number.isFinite(Number(event.threadId))
-            ? Number(event.threadId)
-            : undefined
-          : undefined,
+      channel === "discord"
+        ? undefined
+        : typeof event.threadId === "number"
+          ? event.threadId
+          : typeof event.threadId === "string"
+            ? Number.isFinite(Number(event.threadId))
+              ? Number(event.threadId)
+              : undefined
+            : undefined,
   };
 }
 
@@ -1697,28 +1758,41 @@ export class CodexPluginController {
           );
           const messageId = ctx.interaction.messageId?.trim();
           const builtPicker = await this.tryBuildDiscordPickerMessage(picker);
-          try {
-            if (!builtPicker) {
-              throw new Error("Discord picker rebuild unavailable.");
-            }
-            await ctx.respond.editMessage({
-              components: builtPicker.components,
-            });
-            interactionSettled = true;
-            if (messageId) {
-              await this.registerBuiltDiscordComponentMessage({
-                buildResult: builtPicker,
-                messageId,
+          let alreadyAcknowledged = false;
+          if (builtPicker) {
+            try {
+              await ctx.respond.editMessage({
+                components: builtPicker.components,
               });
+              interactionSettled = true;
+              if (messageId) {
+                await this.registerBuiltDiscordComponentMessage({
+                  buildResult: builtPicker,
+                  messageId,
+                });
+              }
+              return;
+            } catch (error) {
+              const detail = String(error);
+              if (!messageId) {
+                this.api.logger.warn(
+                  `codex discord picker edit failed conversation=${conversationId}: ${detail}`,
+                );
+              } else if (!detail.includes("already been acknowledged")) {
+                await ctx.respond
+                  .acknowledge()
+                  .then(() => {
+                    interactionSettled = true;
+                  })
+                  .catch(() => undefined);
+              } else {
+                alreadyAcknowledged = true;
+              }
             }
-            return;
-          } catch (error) {
-            const detail = String(error);
-            this.api.logger.warn(
-              `codex discord picker edit failed conversation=${conversationId}: ${detail}`,
-            );
-            if (messageId) {
-              if (!detail.includes("already been acknowledged")) {
+          }
+          if (messageId) {
+            try {
+              if (!interactionSettled && !alreadyAcknowledged) {
                 await ctx.respond
                   .acknowledge()
                   .then(() => {
@@ -1735,9 +1809,20 @@ export class CodexPluginController {
                 },
               );
               return;
+            } catch (error) {
+              this.api.logger.warn(
+                `codex discord picker edit failed conversation=${conversationId}: ${String(error)}`,
+              );
             }
           }
-          await this.sendDiscordPicker(conversation, picker);
+          try {
+            await this.sendDiscordPicker(conversation, picker);
+          } catch (error) {
+            this.api.logger.warn(
+              `codex discord picker send failed conversation=${conversationId}: ${String(error)}`,
+            );
+            throw error;
+          }
         },
         requestConversationBinding: async (params) => {
           const requestConversationBinding = bindingApi.requestConversationBinding;
@@ -1792,8 +1877,7 @@ export class CodexPluginController {
         ? await bindingApi.getCurrentConversationBinding()
         : null;
     const pendingBind = conversation ? this.store.getPendingBind(conversation) : null;
-    const existingBinding =
-      conversation && currentBinding ? this.store.getBinding(conversation) : null;
+    const existingBinding = conversation ? this.store.getBinding(conversation) : null;
     const hydratedBinding =
       conversation && currentBinding && !existingBinding
         ? await this.hydrateApprovedBinding(conversation)
@@ -4914,7 +4998,6 @@ export class CodexPluginController {
         cfg: this.getOpenClawConfig(),
         to: conversation.conversationId,
         accountId: conversation.accountId,
-        threadId: conversation.threadId,
         payload: {
           text: picker.text,
           channelData: {
@@ -5025,7 +5108,9 @@ export class CodexPluginController {
     try {
       return await this.buildDiscordPickerMessage(picker);
     } catch (error) {
-      this.api.logger.debug?.(`codex discord picker build fallback: ${String(error)}`);
+      if (!isMissingPluginSdkSubpathError(error, "openclaw/plugin-sdk/discord")) {
+        this.api.logger.debug?.(`codex discord picker build fallback: ${String(error)}`);
+      }
       return undefined;
     }
   }
@@ -6792,7 +6877,6 @@ export class CodexPluginController {
               cfg: this.getOpenClawConfig(),
               to: conversation.conversationId,
               accountId: conversation.accountId,
-              threadId: conversation.threadId,
               mediaLocalRoots,
               payload: {
                 text: finalChunk,
@@ -7019,7 +7103,6 @@ export class CodexPluginController {
         text,
         mediaUrl,
         accountId: conversation.accountId,
-        threadId: conversation.threadId,
         mediaLocalRoots,
       });
     }
@@ -7029,7 +7112,6 @@ export class CodexPluginController {
         to: conversation.conversationId,
         text,
         accountId: conversation.accountId,
-        threadId: conversation.threadId,
       });
     }
     const legacySend = (this.api.runtime.channel as {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -104,6 +104,11 @@ type DiscordSdkModule = typeof import("openclaw/plugin-sdk/discord");
 type TelegramAccountSdkModule = typeof import("openclaw/plugin-sdk/telegram-account");
 type DiscordComponentMessageSpec = import("openclaw/plugin-sdk/discord").DiscordComponentMessageSpec;
 type DiscordComponentBuildResult = ReturnType<DiscordSdkModule["buildDiscordComponentMessage"]>;
+type DiscordExtensionApiModule = {
+  resolveDiscordAccount?: (params: { cfg: unknown; accountId?: string }) => {
+    token?: string;
+  };
+};
 type DiscordRuntimeApiModule = {
   editDiscordComponentMessage?: (
     to: string,
@@ -4968,16 +4973,27 @@ export class CodexPluginController {
         ) => Promise<unknown>;
       };
     }).discord?.sendComponentMessage;
-    if (typeof legacySend !== "function") {
-      throw new Error("Discord component messaging is unavailable.");
+    if (typeof legacySend === "function") {
+      return await legacySend(
+        conversation.conversationId,
+        this.buildDiscordPickerSpec(picker),
+        {
+          accountId: conversation.accountId,
+        },
+      );
     }
-    return await legacySend(
-      conversation.conversationId,
-      this.buildDiscordPickerSpec(picker),
-      {
-        accountId: conversation.accountId,
-      },
-    );
+    const runtimeApi = await this.loadDiscordRuntimeApi();
+    if (typeof runtimeApi?.sendDiscordComponentMessage === "function") {
+      return await runtimeApi.sendDiscordComponentMessage(
+        conversation.conversationId,
+        this.buildDiscordPickerSpec(picker),
+        {
+          cfg: this.getOpenClawConfig(),
+          accountId: conversation.accountId,
+        },
+      );
+    }
+    throw new Error("Discord component messaging is unavailable.");
   }
 
   private buildDiscordPickerSpec(picker: PickerRender): DiscordComponentMessageSpec {
@@ -5045,6 +5061,23 @@ export class CodexPluginController {
       return (await import(pathToFileURL(runtimeApiPath).href)) as DiscordRuntimeApiModule;
     } catch (error) {
       this.api.logger.debug?.(`codex discord runtime api unavailable: ${String(error)}`);
+      return undefined;
+    }
+  }
+
+  private async loadDiscordExtensionApi(): Promise<DiscordExtensionApiModule | undefined> {
+    try {
+      const openClawEntrypointPath = resolveOpenClawEntrypointPath();
+      const apiPath = resolveCompatFallbackPath(
+        openClawEntrypointPath,
+        "dist/extensions/discord/api.js",
+      );
+      if (!existsSync(apiPath)) {
+        return undefined;
+      }
+      return (await import(pathToFileURL(apiPath).href)) as DiscordExtensionApiModule;
+    } catch (error) {
+      this.api.logger.debug?.(`codex discord extension api unavailable: ${String(error)}`);
       return undefined;
     }
   }
@@ -7336,12 +7369,25 @@ export class CodexPluginController {
     if (!cfg) {
       return undefined;
     }
-    const discordSdk = await this.loadDiscordSdk();
-    const account = discordSdk.resolveDiscordAccount({
-      cfg: cfg as Parameters<DiscordSdkModule["resolveDiscordAccount"]>[0]["cfg"],
+    try {
+      const discordSdk = await this.loadDiscordSdk();
+      const account = discordSdk.resolveDiscordAccount({
+        cfg: cfg as Parameters<DiscordSdkModule["resolveDiscordAccount"]>[0]["cfg"],
+        accountId,
+      });
+      const token = account.token?.trim();
+      if (token) {
+        return token;
+      }
+    } catch (error) {
+      this.api.logger.debug?.(`codex discord account facade unavailable: ${String(error)}`);
+    }
+    const discordApi = await this.loadDiscordExtensionApi();
+    const account = discordApi?.resolveDiscordAccount?.({
+      cfg,
       accountId,
     });
-    const token = account.token?.trim();
+    const token = account?.token?.trim();
     return token || undefined;
   }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -159,6 +159,33 @@ type TelegramOutboundAdapter = {
     mediaLocalRoots?: readonly string[];
   }) => Promise<{ messageId: string; chatId?: string }>;
 };
+
+type DiscordOutboundAdapter = {
+  sendText?: (ctx: {
+    cfg: unknown;
+    to: string;
+    text: string;
+    accountId?: string;
+    threadId?: string | number;
+  }) => Promise<{ messageId: string; channelId?: string }>;
+  sendMedia?: (ctx: {
+    cfg: unknown;
+    to: string;
+    text: string;
+    mediaUrl: string;
+    accountId?: string;
+    threadId?: string | number;
+    mediaLocalRoots?: readonly string[];
+  }) => Promise<{ messageId: string; channelId?: string }>;
+  sendPayload?: (ctx: {
+    cfg: unknown;
+    to: string;
+    payload: ReplyPayload;
+    accountId?: string;
+    threadId?: string | number;
+    mediaLocalRoots?: readonly string[];
+  }) => Promise<{ messageId: string; channelId?: string }>;
+};
 const MAX_TEXT_ATTACHMENT_CHARS = 16_000;
 const PLUGIN_VERSION = (() => {
   try {
@@ -4818,7 +4845,63 @@ export class CodexPluginController {
     this.api.logger.debug(
       `codex discord picker send conversation=${conversation.conversationId} rows=${picker.buttons?.length ?? 0}`,
     );
-    await this.api.runtime.channel.discord.sendComponentMessage(
+    const outbound = await this.loadDiscordOutboundAdapter();
+    if (outbound?.sendPayload) {
+      await outbound.sendPayload({
+        cfg: this.getOpenClawConfig(),
+        to: conversation.conversationId,
+        accountId: conversation.accountId,
+        threadId: conversation.threadId,
+        payload: {
+          text: picker.text,
+          channelData: {
+            discord: {
+              components: this.buildDiscordPickerSpec(picker),
+            },
+          },
+        },
+      });
+      return;
+    }
+    const legacySend = (this.api.runtime.channel as {
+      discord?: {
+        sendComponentMessage?: (
+          to: string,
+          spec: DiscordComponentMessageSpec,
+          opts?: { accountId?: string },
+        ) => Promise<unknown>;
+      };
+    }).discord?.sendComponentMessage;
+    if (typeof legacySend === "function") {
+      await legacySend(
+        conversation.conversationId,
+        this.buildDiscordPickerSpec(picker),
+        {
+          accountId: conversation.accountId,
+        },
+      );
+      return;
+    }
+    throw new Error("Discord component messaging is unavailable.");
+  }
+
+  private async sendDiscordPickerMessageLegacy(
+    conversation: ConversationTarget,
+    picker: PickerRender,
+  ): Promise<unknown> {
+    const legacySend = (this.api.runtime.channel as {
+      discord?: {
+        sendComponentMessage?: (
+          to: string,
+          spec: DiscordComponentMessageSpec,
+          opts?: { accountId?: string },
+        ) => Promise<unknown>;
+      };
+    }).discord?.sendComponentMessage;
+    if (typeof legacySend !== "function") {
+      throw new Error("Discord component messaging is unavailable.");
+    }
+    return await legacySend(
       conversation.conversationId,
       this.buildDiscordPickerSpec(picker),
       {
@@ -6507,6 +6590,7 @@ export class CodexPluginController {
       return delivered;
     }
     if (isDiscordChannel(conversation.channel)) {
+      const outbound = await this.loadDiscordOutboundAdapter();
       const mediaLocalRoots = this.resolveReplyMediaLocalRoots(payload.mediaUrl);
       const limit = this.api.runtime.channel.text.resolveTextChunkLimit(
         undefined,
@@ -6524,51 +6608,56 @@ export class CodexPluginController {
         );
         const attachmentChunk = hasMedia ? (chunks.shift() ?? text) : undefined;
         if (hasMedia) {
-          const result = await this.api.runtime.channel.discord.sendMessageDiscord(
-            conversation.conversationId,
-            attachmentChunk ?? "",
-            {
-              accountId: conversation.accountId,
-              mediaUrl: payload.mediaUrl,
-              mediaLocalRoots,
-            },
-          );
+          const result = await this.sendDiscordTextChunk(outbound, conversation, attachmentChunk ?? "", {
+            mediaUrl: payload.mediaUrl,
+            mediaLocalRoots,
+          });
           delivered = {
             provider: "discord",
             messageId: result.messageId,
-            channelId: result.channelId,
+            channelId:
+              typeof result.channelId === "string"
+                ? result.channelId
+                : conversation.conversationId,
           };
         }
         const finalChunk = chunks.pop() ?? (hasMedia ? "" : text);
         for (const chunk of chunks) {
-          const result = await this.api.runtime.channel.discord.sendMessageDiscord(conversation.conversationId, chunk, {
-            accountId: conversation.accountId,
-          });
+          const result = await this.sendDiscordTextChunk(outbound, conversation, chunk);
           if (!delivered) {
             delivered = {
               provider: "discord",
               messageId: result.messageId,
-              channelId: result.channelId,
+              channelId:
+                typeof result.channelId === "string"
+                  ? result.channelId
+                  : conversation.conversationId,
             };
           }
         }
-        const result = await this.api.runtime.channel.discord.sendComponentMessage(
-          conversation.conversationId,
-          {
-            text: finalChunk,
-            blocks: payload.buttons.map((row) => ({
-              type: "actions" as const,
-              buttons: row.map((button) => ({
-                label: truncateDiscordLabel(button.text),
-                style: "primary" as const,
-                callbackData: button.callback_data,
-              })),
-            })),
-          },
-          {
-            accountId: conversation.accountId,
-          },
-        );
+        const result = outbound?.sendPayload
+          ? await outbound.sendPayload({
+              cfg: this.getOpenClawConfig(),
+              to: conversation.conversationId,
+              accountId: conversation.accountId,
+              threadId: conversation.threadId,
+              mediaLocalRoots,
+              payload: {
+                text: finalChunk,
+                channelData: {
+                  discord: {
+                    components: this.buildDiscordPickerSpec({
+                      text: finalChunk,
+                      buttons: payload.buttons,
+                    }),
+                  },
+                },
+              },
+            })
+          : await this.sendDiscordPickerMessageLegacy(conversation, {
+              text: finalChunk,
+              buttons: payload.buttons,
+            });
         if (
           result &&
           typeof result === "object" &&
@@ -6578,7 +6667,10 @@ export class CodexPluginController {
           delivered = {
             provider: "discord",
             messageId: (result as { messageId: string }).messageId,
-            channelId: (result as { channelId: string }).channelId,
+            channelId:
+              typeof (result as { channelId?: unknown }).channelId === "string"
+                ? (result as { channelId: string }).channelId
+                : conversation.conversationId,
           };
         }
         this.api.logger.debug?.(
@@ -6589,33 +6681,30 @@ export class CodexPluginController {
       const textChunks = chunks.length > 0 ? chunks : [text];
       if (hasMedia) {
         const firstChunk = textChunks.shift() ?? "";
-        const result = await this.api.runtime.channel.discord.sendMessageDiscord(
-          conversation.conversationId,
-          firstChunk,
-          {
-            accountId: conversation.accountId,
-            mediaUrl: payload.mediaUrl,
-            mediaLocalRoots,
-          },
-        );
+        const result = await this.sendDiscordTextChunk(outbound, conversation, firstChunk, {
+          mediaUrl: payload.mediaUrl,
+          mediaLocalRoots,
+        });
         delivered = {
           provider: "discord",
           messageId: result.messageId,
-          channelId: result.channelId,
+          channelId:
+            typeof result.channelId === "string" ? result.channelId : conversation.conversationId,
         };
       }
       for (const chunk of textChunks) {
         if (!chunk) {
           continue;
         }
-        const result = await this.api.runtime.channel.discord.sendMessageDiscord(conversation.conversationId, chunk, {
-          accountId: conversation.accountId,
-        });
+        const result = await this.sendDiscordTextChunk(outbound, conversation, chunk);
         if (!delivered) {
           delivered = {
             provider: "discord",
             messageId: result.messageId,
-            channelId: result.channelId,
+            channelId:
+              typeof result.channelId === "string"
+                ? result.channelId
+                : conversation.conversationId,
           };
         }
       }
@@ -6637,6 +6726,14 @@ export class CodexPluginController {
       return undefined;
     }
     return (await loadAdapter("telegram")) as TelegramOutboundAdapter | undefined;
+  }
+
+  private async loadDiscordOutboundAdapter(): Promise<DiscordOutboundAdapter | undefined> {
+    const loadAdapter = this.api.runtime.channel.outbound?.loadAdapter;
+    if (typeof loadAdapter !== "function") {
+      return undefined;
+    }
+    return (await loadAdapter("discord")) as DiscordOutboundAdapter | undefined;
   }
 
   private async sendTelegramTextChunk(
@@ -6755,6 +6852,57 @@ export class CodexPluginController {
     });
   }
 
+  private async sendDiscordTextChunk(
+    outbound: DiscordOutboundAdapter | undefined,
+    conversation: ConversationTarget,
+    text: string,
+    opts?: { mediaUrl?: string; mediaLocalRoots?: readonly string[] },
+  ): Promise<{ messageId: string; channelId?: string }> {
+    const mediaUrl = opts?.mediaUrl;
+    const mediaLocalRoots = opts?.mediaLocalRoots;
+    if (mediaUrl && outbound?.sendMedia) {
+      return await outbound.sendMedia({
+        cfg: this.getOpenClawConfig(),
+        to: conversation.conversationId,
+        text,
+        mediaUrl,
+        accountId: conversation.accountId,
+        threadId: conversation.threadId,
+        mediaLocalRoots,
+      });
+    }
+    if (!mediaUrl && outbound?.sendText) {
+      return await outbound.sendText({
+        cfg: this.getOpenClawConfig(),
+        to: conversation.conversationId,
+        text,
+        accountId: conversation.accountId,
+        threadId: conversation.threadId,
+      });
+    }
+    const legacySend = (this.api.runtime.channel as {
+      discord?: {
+        sendMessageDiscord?: (
+          to: string,
+          text: string,
+          opts?: {
+            accountId?: string;
+            mediaUrl?: string;
+            mediaLocalRoots?: readonly string[];
+          },
+        ) => Promise<{ messageId: string; channelId: string }>;
+      };
+    }).discord?.sendMessageDiscord;
+    if (typeof legacySend === "function") {
+      return await legacySend(conversation.conversationId, text, {
+        accountId: conversation.accountId,
+        mediaUrl,
+        mediaLocalRoots,
+      });
+    }
+    throw new Error("Discord outbound messaging is unavailable.");
+  }
+
   private resolveReplyMediaLocalRoots(mediaUrl?: string): readonly string[] | undefined {
     const rawValue = mediaUrl?.trim();
     if (!rawValue) {
@@ -6829,7 +6977,20 @@ export class CodexPluginController {
       }
       const channelId =
         denormalizeDiscordConversationId(conversation.conversationId) ?? conversation.conversationId;
-      return await this.api.runtime.channel.discord.typing.start({
+      const legacyTyping = (this.api.runtime.channel as {
+        discord?: {
+          typing?: {
+            start?: (params: {
+              channelId: string;
+              accountId?: string;
+            }) => Promise<{ refresh: () => Promise<void>; stop: () => void }>;
+          };
+        };
+      }).discord?.typing?.start;
+      if (typeof legacyTyping !== "function") {
+        return null;
+      }
+      return await legacyTyping({
         channelId,
         accountId: conversation.accountId,
       });
@@ -6883,6 +7044,7 @@ export class CodexPluginController {
       return firstDelivered;
     }
     if (isDiscordChannel(conversation.channel)) {
+      const outbound = await this.loadDiscordOutboundAdapter();
       const limit = this.api.runtime.channel.text.resolveTextChunkLimit(
         undefined,
         "discord",
@@ -6893,18 +7055,15 @@ export class CodexPluginController {
       const textChunks = chunks.length > 0 ? chunks : [trimmed];
       let firstDelivered: DeliveredMessageRef | null = null;
       for (const chunk of textChunks) {
-        const result = await this.api.runtime.channel.discord.sendMessageDiscord(
-          conversation.conversationId,
-          chunk,
-          {
-            accountId: conversation.accountId,
-          },
-        );
+        const result = await this.sendDiscordTextChunk(outbound, conversation, chunk);
         if (!firstDelivered) {
           firstDelivered = {
             provider: "discord",
             messageId: result.messageId,
-            channelId: result.channelId,
+            channelId:
+              typeof result.channelId === "string"
+                ? result.channelId
+                : conversation.conversationId,
           };
         }
       }
@@ -7193,7 +7352,21 @@ export class CodexPluginController {
       return;
     }
     if (isDiscordChannel(conversation.channel)) {
-      await this.api.runtime.channel.discord.conversationActions.editChannel(
+      const legacyEditChannel = (this.api.runtime.channel as {
+        discord?: {
+          conversationActions?: {
+            editChannel?: (
+              channelId: string,
+              params: { name?: string },
+              opts?: { accountId?: string },
+            ) => Promise<unknown>;
+          };
+        };
+      }).discord?.conversationActions?.editChannel;
+      if (typeof legacyEditChannel !== "function") {
+        return;
+      }
+      await legacyEditChannel(
         conversation.conversationId,
         {
           name,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -96,6 +96,7 @@ import {
 } from "./types.js";
 import {
   loadOpenClawCompatModule,
+  resolveOpenClawEntrypointPath,
   resolveCompatFallbackPath,
 } from "./openclaw-sdk-compat.js";
 
@@ -5004,7 +5005,7 @@ export class CodexPluginController {
 
   private async loadDiscordRuntimeApi(): Promise<DiscordRuntimeApiModule | undefined> {
     try {
-      const openClawEntrypointPath = require.resolve("openclaw");
+      const openClawEntrypointPath = resolveOpenClawEntrypointPath();
       const runtimeApiPath = resolveCompatFallbackPath(
         openClawEntrypointPath,
         "dist/extensions/discord/runtime-api.js",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -105,6 +105,19 @@ type TelegramAccountSdkModule = typeof import("openclaw/plugin-sdk/telegram-acco
 type DiscordComponentMessageSpec = import("openclaw/plugin-sdk/discord").DiscordComponentMessageSpec;
 type DiscordComponentBuildResult = ReturnType<DiscordSdkModule["buildDiscordComponentMessage"]>;
 type DiscordRuntimeApiModule = {
+  editDiscordComponentMessage?: (
+    to: string,
+    messageId: string,
+    spec: DiscordComponentMessageSpec,
+    opts?: {
+      cfg?: unknown;
+      accountId?: string;
+    },
+  ) => Promise<{ messageId: string; channelId: string }>;
+  registerBuiltDiscordComponentMessage?: (params: {
+    buildResult: DiscordComponentBuildResult;
+    messageId: string;
+  }) => void;
   sendDiscordComponentMessage?: (
     to: string,
     spec: DiscordComponentMessageSpec,
@@ -1678,8 +1691,11 @@ export class CodexPluginController {
             `codex discord picker refresh conversation=${conversationId} rows=${picker.buttons?.length ?? 0}`,
           );
           const messageId = ctx.interaction.messageId?.trim();
-          const builtPicker = await this.buildDiscordPickerMessage(picker);
+          const builtPicker = await this.tryBuildDiscordPickerMessage(picker);
           try {
+            if (!builtPicker) {
+              throw new Error("Discord picker rebuild unavailable.");
+            }
             await ctx.respond.editMessage({
               components: builtPicker.components,
             });
@@ -2533,7 +2549,7 @@ export class CodexPluginController {
       const builtPicker = await this.buildDiscordPickerMessage({
         text: statusCard.text,
         buttons: statusCard.buttons,
-      });
+      }).catch(() => undefined);
       await this.editDiscordComponentMessage(
         message.channelId,
         message.messageId,
@@ -2545,10 +2561,12 @@ export class CodexPluginController {
           accountId: conversation.accountId,
         },
       );
-      await this.registerBuiltDiscordComponentMessage({
-        buildResult: builtPicker,
-        messageId: message.messageId,
-      });
+      if (builtPicker) {
+        await this.registerBuiltDiscordComponentMessage({
+          buildResult: builtPicker,
+          messageId: message.messageId,
+        });
+      }
       return true;
     } catch (error) {
       this.api.logger.warn(
@@ -4985,6 +5003,17 @@ export class CodexPluginController {
     });
   }
 
+  private async tryBuildDiscordPickerMessage(
+    picker: PickerRender,
+  ): Promise<DiscordComponentBuildResult | undefined> {
+    try {
+      return await this.buildDiscordPickerMessage(picker);
+    } catch (error) {
+      this.api.logger.debug?.(`codex discord picker build fallback: ${String(error)}`);
+      return undefined;
+    }
+  }
+
   private async loadDiscordSdk(): Promise<DiscordSdkModule> {
     return await loadOpenClawCompatModule<DiscordSdkModule>({
       specifier: "openclaw/plugin-sdk/discord",
@@ -5026,16 +5055,37 @@ export class CodexPluginController {
     spec: DiscordComponentMessageSpec,
     opts?: { accountId?: string },
   ): Promise<{ messageId: string; channelId: string }> {
-    const discordSdk = await this.loadDiscordSdk();
-    return await discordSdk.editDiscordComponentMessage(to, messageId, spec, opts);
+    try {
+      const discordSdk = await this.loadDiscordSdk();
+      return await discordSdk.editDiscordComponentMessage(to, messageId, spec, opts);
+    } catch (error) {
+      const runtimeApi = await this.loadDiscordRuntimeApi();
+      if (typeof runtimeApi?.editDiscordComponentMessage === "function") {
+        return await runtimeApi.editDiscordComponentMessage(to, messageId, spec, {
+          cfg: this.getOpenClawConfig(),
+          accountId: opts?.accountId,
+        });
+      }
+      throw error;
+    }
   }
 
   private async registerBuiltDiscordComponentMessage(params: {
     buildResult: DiscordComponentBuildResult;
     messageId: string;
   }): Promise<void> {
-    const discordSdk = await this.loadDiscordSdk();
-    discordSdk.registerBuiltDiscordComponentMessage(params);
+    try {
+      const discordSdk = await this.loadDiscordSdk();
+      discordSdk.registerBuiltDiscordComponentMessage(params);
+      return;
+    } catch (error) {
+      const runtimeApi = await this.loadDiscordRuntimeApi();
+      if (typeof runtimeApi?.registerBuiltDiscordComponentMessage === "function") {
+        runtimeApi.registerBuiltDiscordComponentMessage(params);
+        return;
+      }
+      throw error;
+    }
   }
 
   private async dispatchCallbackAction(

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync, promises as fs } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type {
   PluginConversationBindingResolvedEvent,
@@ -94,12 +94,51 @@ import {
   type StoredPendingBind,
   type StoredPendingRequest,
 } from "./types.js";
-import { loadOpenClawCompatModule } from "./openclaw-sdk-compat.js";
+import {
+  loadOpenClawCompatModule,
+  resolveCompatFallbackPath,
+} from "./openclaw-sdk-compat.js";
 
 type DiscordSdkModule = typeof import("openclaw/plugin-sdk/discord");
 type TelegramAccountSdkModule = typeof import("openclaw/plugin-sdk/telegram-account");
 type DiscordComponentMessageSpec = import("openclaw/plugin-sdk/discord").DiscordComponentMessageSpec;
 type DiscordComponentBuildResult = ReturnType<DiscordSdkModule["buildDiscordComponentMessage"]>;
+type DiscordRuntimeApiModule = {
+  sendDiscordComponentMessage?: (
+    to: string,
+    spec: DiscordComponentMessageSpec,
+    opts?: {
+      cfg?: unknown;
+      accountId?: string;
+      mediaUrl?: string;
+      mediaLocalRoots?: readonly string[];
+    },
+  ) => Promise<{ messageId: string; channelId: string }>;
+  sendMessageDiscord?: (
+    to: string,
+    text: string,
+    opts?: {
+      cfg?: unknown;
+      accountId?: string;
+      mediaUrl?: string;
+      mediaLocalRoots?: readonly string[];
+    },
+  ) => Promise<{ messageId: string; channelId: string }>;
+  sendTypingDiscord?: (
+    channelId: string,
+    opts?: {
+      cfg?: unknown;
+      accountId?: string;
+    },
+  ) => Promise<unknown>;
+  editChannelDiscord?: (
+    payload: { channelId: string; name?: string },
+    opts?: {
+      cfg?: unknown;
+      accountId?: string;
+    },
+  ) => Promise<unknown>;
+};
 
 type ActiveRunRecord = {
   conversation: ConversationTarget;
@@ -4882,6 +4921,18 @@ export class CodexPluginController {
       );
       return;
     }
+    const runtimeApi = await this.loadDiscordRuntimeApi();
+    if (typeof runtimeApi?.sendDiscordComponentMessage === "function") {
+      await runtimeApi.sendDiscordComponentMessage(
+        conversation.conversationId,
+        this.buildDiscordPickerSpec(picker),
+        {
+          cfg: this.getOpenClawConfig(),
+          accountId: conversation.accountId,
+        },
+      );
+      return;
+    }
     throw new Error("Discord component messaging is unavailable.");
   }
 
@@ -4949,6 +5000,23 @@ export class CodexPluginController {
       label: "telegram account",
       logger: this.api.logger,
     });
+  }
+
+  private async loadDiscordRuntimeApi(): Promise<DiscordRuntimeApiModule | undefined> {
+    try {
+      const openClawEntrypointPath = require.resolve("openclaw");
+      const runtimeApiPath = resolveCompatFallbackPath(
+        openClawEntrypointPath,
+        "dist/extensions/discord/runtime-api.js",
+      );
+      if (!existsSync(runtimeApiPath)) {
+        return undefined;
+      }
+      return (await import(pathToFileURL(runtimeApiPath).href)) as DiscordRuntimeApiModule;
+    } catch (error) {
+      this.api.logger.debug?.(`codex discord runtime api unavailable: ${String(error)}`);
+      return undefined;
+    }
   }
 
   private async editDiscordComponentMessage(
@@ -6900,6 +6968,15 @@ export class CodexPluginController {
         mediaLocalRoots,
       });
     }
+    const runtimeApi = await this.loadDiscordRuntimeApi();
+    if (typeof runtimeApi?.sendMessageDiscord === "function") {
+      return await runtimeApi.sendMessageDiscord(conversation.conversationId, text, {
+        cfg: this.getOpenClawConfig(),
+        accountId: conversation.accountId,
+        mediaUrl,
+        mediaLocalRoots,
+      });
+    }
     throw new Error("Discord outbound messaging is unavailable.");
   }
 
@@ -6959,6 +7036,7 @@ export class CodexPluginController {
 
   private async startTypingLease(conversation: ConversationTarget): Promise<{
     stop: () => void;
+    refresh?: () => Promise<void>;
   } | null> {
     if (isTelegramChannel(conversation.channel)) {
       const legacyTyping = this.api.runtime.channel.telegram?.typing?.start;
@@ -6988,7 +7066,28 @@ export class CodexPluginController {
         };
       }).discord?.typing?.start;
       if (typeof legacyTyping !== "function") {
-        return null;
+        const runtimeApi = await this.loadDiscordRuntimeApi();
+        if (typeof runtimeApi?.sendTypingDiscord !== "function") {
+          return null;
+        }
+        const sendTyping = async () => {
+          await runtimeApi.sendTypingDiscord?.(channelId, {
+            cfg: this.getOpenClawConfig(),
+            accountId: conversation.accountId,
+          });
+        };
+        await sendTyping().catch((error) => {
+          this.api.logger.debug?.(`codex discord typing skipped: ${String(error)}`);
+        });
+        const timer = setInterval(() => {
+          void sendTyping().catch((error) => {
+            this.api.logger.debug?.(`codex discord typing refresh failed: ${String(error)}`);
+          });
+        }, 4_000);
+        return {
+          refresh: sendTyping,
+          stop: () => clearInterval(timer),
+        };
       }
       return await legacyTyping({
         channelId,
@@ -7364,6 +7463,24 @@ export class CodexPluginController {
         };
       }).discord?.conversationActions?.editChannel;
       if (typeof legacyEditChannel !== "function") {
+        const runtimeApi = await this.loadDiscordRuntimeApi();
+        if (typeof runtimeApi?.editChannelDiscord !== "function") {
+          return;
+        }
+        await runtimeApi.editChannelDiscord(
+          {
+            channelId:
+              denormalizeDiscordConversationId(conversation.conversationId) ??
+              conversation.conversationId,
+            name,
+          },
+          {
+            cfg: this.getOpenClawConfig(),
+            accountId: conversation.accountId,
+          },
+        ).catch((error) => {
+          this.api.logger.warn(`codex discord channel rename failed: ${String(error)}`);
+        });
         return;
       }
       await legacyEditChannel(

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -46,7 +46,8 @@ declare module "openclaw/plugin-sdk" {
     from?: string;
     to?: string;
     accountId?: string;
-    messageThreadId?: number;
+    messageThreadId?: string | number;
+    threadParentId?: string;
     media?: PluginInboundMedia[];
   };
 

--- a/src/openclaw-sdk-compat.test.ts
+++ b/src/openclaw-sdk-compat.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isMissingPluginSdkSubpathError,
+  loadOpenClawCompatModule,
+  resolveCompatFallbackPath,
+} from "./openclaw-sdk-compat.js";
+
+describe("openclaw sdk compat", () => {
+  it("detects removed plugin sdk subpath exports", () => {
+    const error = Object.assign(
+      new Error('Package subpath "./plugin-sdk/discord" is not defined by "exports"'),
+      {
+        code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
+      },
+    );
+
+    expect(isMissingPluginSdkSubpathError(error, "openclaw/plugin-sdk/discord")).toBe(true);
+  });
+
+  it("resolves fallback paths from the OpenClaw entrypoint", () => {
+    expect(
+      resolveCompatFallbackPath(
+        "/tmp/node_modules/openclaw/dist/index.js",
+        "dist/plugin-sdk/discord.js",
+      ),
+    ).toBe("/tmp/node_modules/openclaw/dist/plugin-sdk/discord.js");
+  });
+
+  it("falls back to the dist facade when the public subpath is gone", async () => {
+    const importer = vi.fn(async (specifier: string) => {
+      if (specifier === "openclaw/plugin-sdk/discord") {
+        throw Object.assign(
+          new Error('Package subpath "./plugin-sdk/discord" is not defined by "exports"'),
+          {
+            code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
+          },
+        );
+      }
+      return { ok: true, specifier };
+    });
+
+    const result = await loadOpenClawCompatModule<{ ok: boolean; specifier: string }>({
+      specifier: "openclaw/plugin-sdk/discord",
+      fallbackRelativePath: "dist/plugin-sdk/discord.js",
+      label: "discord",
+      importer,
+      resolver: () => "/tmp/node_modules/openclaw/dist/index.js",
+      pathExists: () => true,
+      cache: new Map(),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      specifier: "file:///tmp/node_modules/openclaw/dist/plugin-sdk/discord.js",
+    });
+    expect(importer).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows non-resolution failures from the public import", async () => {
+    const importer = vi.fn(async (_specifier: string) => {
+      throw new Error("boom");
+    });
+
+    await expect(
+      loadOpenClawCompatModule({
+        specifier: "openclaw/plugin-sdk/discord",
+        fallbackRelativePath: "dist/plugin-sdk/discord.js",
+        label: "discord",
+        importer,
+        resolver: () => "/tmp/node_modules/openclaw/dist/index.js",
+        pathExists: () => true,
+        cache: new Map(),
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/openclaw-sdk-compat.test.ts
+++ b/src/openclaw-sdk-compat.test.ts
@@ -3,6 +3,7 @@ import {
   isMissingPluginSdkSubpathError,
   loadOpenClawCompatModule,
   resolveCompatFallbackPath,
+  resolveOpenClawEntrypointPath,
 } from "./openclaw-sdk-compat.js";
 
 describe("openclaw sdk compat", () => {
@@ -54,6 +55,40 @@ describe("openclaw sdk compat", () => {
       specifier: "file:///tmp/node_modules/openclaw/dist/plugin-sdk/discord.js",
     });
     expect(importer).toHaveBeenCalledTimes(2);
+  });
+
+  it("prefers the host OpenClaw checkout from argv/cwd over the local dependency", () => {
+    const files = new Map<string, string>([
+      [
+        "/host/openclaw/package.json",
+        JSON.stringify({
+          name: "openclaw",
+          exports: {
+            "./plugin-sdk": { default: "./dist/plugin-sdk/index.js" },
+            "./cli-entry": { default: "./dist/cli-entry.js" },
+          },
+        }),
+      ],
+    ]);
+
+    const result = resolveOpenClawEntrypointPath({
+      argv1: "/host/openclaw/openclaw.mjs",
+      cwd: "/host/openclaw",
+      pathExists: (targetPath) =>
+        targetPath === "/host/openclaw/openclaw.mjs" ||
+        targetPath === "/host/openclaw/dist/index.js" ||
+        files.has(targetPath),
+      readFile: (targetPath) => {
+        const content = files.get(targetPath);
+        if (!content) {
+          throw new Error(`missing ${targetPath}`);
+        }
+        return content;
+      },
+      resolver: () => "/repo/openclaw-app-server/node_modules/openclaw/dist/index.js",
+    });
+
+    expect(result).toBe("/host/openclaw/dist/index.js");
   });
 
   it("rethrows non-resolution failures from the public import", async () => {

--- a/src/openclaw-sdk-compat.test.ts
+++ b/src/openclaw-sdk-compat.test.ts
@@ -18,6 +18,18 @@ describe("openclaw sdk compat", () => {
     expect(isMissingPluginSdkSubpathError(error, "openclaw/plugin-sdk/discord")).toBe(true);
   });
 
+  it("detects missing plugin sdk subpaths from object-like jiti errors", () => {
+    expect(
+      isMissingPluginSdkSubpathError(
+        {
+          message:
+            "Cannot find module '/Users/huntharo/github/openclaw/dist/plugin-sdk/root-alias.cjs/discord'",
+        },
+        "openclaw/plugin-sdk/discord",
+      ),
+    ).toBe(true);
+  });
+
   it("resolves fallback paths from the OpenClaw entrypoint", () => {
     expect(
       resolveCompatFallbackPath(

--- a/src/openclaw-sdk-compat.ts
+++ b/src/openclaw-sdk-compat.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -12,6 +12,7 @@ export type PluginSdkCompatLogger = {
 type CompatImporter = (specifier: string) => Promise<unknown>;
 type CompatResolver = (specifier: string) => string;
 type CompatPathExists = (targetPath: string) => boolean;
+type CompatReadFile = (targetPath: string) => string;
 
 const compatModuleCache = new Map<string, Promise<unknown>>();
 
@@ -43,6 +44,93 @@ export function resolveCompatFallbackPath(
   return path.resolve(path.dirname(openClawEntrypointPath), "..", fallbackRelativePath);
 }
 
+function readPackageJsonNameAndExports(
+  packageRoot: string,
+  readFile: CompatReadFile,
+): { name?: string; exports?: Record<string, unknown>; bin?: string | Record<string, unknown> } | null {
+  try {
+    return JSON.parse(readFile(path.join(packageRoot, "package.json"))) as {
+      name?: string;
+      exports?: Record<string, unknown>;
+      bin?: string | Record<string, unknown>;
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isTrustedOpenClawRoot(
+  packageRoot: string,
+  pathExists: CompatPathExists,
+  readFile: CompatReadFile,
+): boolean {
+  const pkg = readPackageJsonNameAndExports(packageRoot, readFile);
+  if (!pkg || pkg.name !== "openclaw") {
+    return false;
+  }
+  const exports = pkg.exports ?? {};
+  if (!Object.prototype.hasOwnProperty.call(exports, "./plugin-sdk")) {
+    return false;
+  }
+  const hasCliEntry = Object.prototype.hasOwnProperty.call(exports, "./cli-entry");
+  const hasOpenClawBin =
+    (typeof pkg.bin === "string" && pkg.bin.toLowerCase().includes("openclaw")) ||
+    (typeof pkg.bin === "object" &&
+      pkg.bin !== null &&
+      typeof pkg.bin.openclaw === "string");
+  return hasCliEntry || hasOpenClawBin || pathExists(path.join(packageRoot, "openclaw.mjs"));
+}
+
+function resolveTrustedOpenClawRootFromStart(
+  startPath: string | undefined,
+  pathExists: CompatPathExists,
+  readFile: CompatReadFile,
+): string | null {
+  if (!startPath) {
+    return null;
+  }
+  let cursor = path.resolve(startPath);
+  if (!path.extname(cursor)) {
+    // Keep directory-like hints as-is.
+  } else {
+    cursor = path.dirname(cursor);
+  }
+  for (let depth = 0; depth < 12; depth += 1) {
+    if (isTrustedOpenClawRoot(cursor, pathExists, readFile)) {
+      return cursor;
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  return null;
+}
+
+export function resolveOpenClawEntrypointPath(params?: {
+  resolver?: CompatResolver;
+  pathExists?: CompatPathExists;
+  readFile?: CompatReadFile;
+  argv1?: string;
+  cwd?: string;
+}): string {
+  const resolver = params?.resolver ?? ((specifier: string) => require.resolve(specifier));
+  const pathExists = params?.pathExists ?? existsSync;
+  const readFile = params?.readFile ?? ((targetPath: string) => readFileSync(targetPath, "utf-8"));
+  const hostRoot =
+    resolveTrustedOpenClawRootFromStart(params?.argv1 ?? process.argv[1], pathExists, readFile) ??
+    resolveTrustedOpenClawRootFromStart(params?.cwd ?? process.cwd(), pathExists, readFile);
+  if (hostRoot) {
+    const distEntrypoint = path.join(hostRoot, "dist", "index.js");
+    if (pathExists(distEntrypoint)) {
+      return distEntrypoint;
+    }
+    return path.join(hostRoot, "src", "index.ts");
+  }
+  return resolver("openclaw");
+}
+
 export async function loadOpenClawCompatModule<T>(params: {
   specifier: string;
   fallbackRelativePath: string;
@@ -61,7 +149,6 @@ export async function loadOpenClawCompatModule<T>(params: {
   }
 
   const importer = params.importer ?? (async (specifier: string) => await import(specifier));
-  const resolver = params.resolver ?? ((specifier: string) => require.resolve(specifier));
   const pathExists = params.pathExists ?? existsSync;
 
   const promise = (async () => {
@@ -72,7 +159,10 @@ export async function loadOpenClawCompatModule<T>(params: {
         throw error;
       }
 
-      const openClawEntrypointPath = resolver("openclaw");
+      const openClawEntrypointPath = resolveOpenClawEntrypointPath({
+        resolver: params.resolver,
+        pathExists,
+      });
       const fallbackPath = resolveCompatFallbackPath(
         openClawEntrypointPath,
         params.fallbackRelativePath,

--- a/src/openclaw-sdk-compat.ts
+++ b/src/openclaw-sdk-compat.ts
@@ -17,11 +17,16 @@ type CompatReadFile = (targetPath: string) => string;
 const compatModuleCache = new Map<string, Promise<unknown>>();
 
 export function isMissingPluginSdkSubpathError(error: unknown, specifier: string): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  const code = (error as NodeJS.ErrnoException).code;
-  const message = error.message ?? "";
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : "";
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "")
+      : error instanceof Error
+        ? error.message ?? ""
+        : "";
   if (code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
     return true;
   }

--- a/src/openclaw-sdk-compat.ts
+++ b/src/openclaw-sdk-compat.ts
@@ -1,0 +1,95 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export type PluginSdkCompatLogger = {
+  debug?: (message: string) => void;
+};
+
+type CompatImporter = (specifier: string) => Promise<unknown>;
+type CompatResolver = (specifier: string) => string;
+type CompatPathExists = (targetPath: string) => boolean;
+
+const compatModuleCache = new Map<string, Promise<unknown>>();
+
+export function isMissingPluginSdkSubpathError(error: unknown, specifier: string): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  const message = error.message ?? "";
+  if (code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+    return true;
+  }
+  if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
+    return true;
+  }
+  return (
+    message.includes("Cannot find module") ||
+    message.includes("Cannot find package") ||
+    message.includes('is not defined by "exports"') ||
+    message.includes(specifier) ||
+    message.includes("/plugin-sdk/root-alias.cjs/")
+  );
+}
+
+export function resolveCompatFallbackPath(
+  openClawEntrypointPath: string,
+  fallbackRelativePath: string,
+): string {
+  return path.resolve(path.dirname(openClawEntrypointPath), "..", fallbackRelativePath);
+}
+
+export async function loadOpenClawCompatModule<T>(params: {
+  specifier: string;
+  fallbackRelativePath: string;
+  label: string;
+  logger?: PluginSdkCompatLogger;
+  importer?: CompatImporter;
+  resolver?: CompatResolver;
+  pathExists?: CompatPathExists;
+  cache?: Map<string, Promise<unknown>>;
+}): Promise<T> {
+  const cache = params.cache ?? compatModuleCache;
+  const cacheKey = `${params.specifier}::${params.fallbackRelativePath}`;
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return (await cached) as T;
+  }
+
+  const importer = params.importer ?? (async (specifier: string) => await import(specifier));
+  const resolver = params.resolver ?? ((specifier: string) => require.resolve(specifier));
+  const pathExists = params.pathExists ?? existsSync;
+
+  const promise = (async () => {
+    try {
+      return (await importer(params.specifier)) as T;
+    } catch (error) {
+      if (!isMissingPluginSdkSubpathError(error, params.specifier)) {
+        throw error;
+      }
+
+      const openClawEntrypointPath = resolver("openclaw");
+      const fallbackPath = resolveCompatFallbackPath(
+        openClawEntrypointPath,
+        params.fallbackRelativePath,
+      );
+      if (!pathExists(fallbackPath)) {
+        throw error;
+      }
+      params.logger?.debug?.(`codex ${params.label} sdk fallback using ${fallbackPath}`);
+      return (await importer(pathToFileURL(fallbackPath).href)) as T;
+    }
+  })();
+
+  cache.set(cacheKey, promise);
+  try {
+    return (await promise) as T;
+  } catch (error) {
+    cache.delete(cacheKey);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- I replaced the load-time `openclaw/plugin-sdk/discord` import with a lazy compatibility loader that first tries the old public SDK path and then falls back to the generated `dist/plugin-sdk/*.js` facades used by newer OpenClaw checkouts.
- I reused the same compatibility path for Telegram account resolution so later SDK export cleanup does not break that path the way Discord just did.
- I updated the README compatibility notes to call out the released support boundary through `v2026.4.2` and the newer local checkout behavior seen on `2026.4.5`.

## Testing

- I ran `pnpm test`.
- I ran `pnpm typecheck`.
