### PR TITLE
Plugin: use structural types for plugin-sdk subpath modules

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -101,10 +101,46 @@ import {
   resolveCompatFallbackPath,
 } from "./openclaw-sdk-compat.js";
 
-type DiscordSdkModule = typeof import("openclaw/plugin-sdk/discord");
-type TelegramAccountSdkModule = typeof import("openclaw/plugin-sdk/telegram-account");
-type DiscordComponentMessageSpec = import("openclaw/plugin-sdk/discord").DiscordComponentMessageSpec;
-type DiscordComponentBuildResult = ReturnType<DiscordSdkModule["buildDiscordComponentMessage"]>;
+// Structural types for lazily-loaded plugin-sdk subpath modules.
+// These must NOT use `typeof import("openclaw/plugin-sdk/...")` because jiti
+// resolves those at load time, which breaks on OpenClaw >=2026.4.2 where the
+// subpath exports were removed (see #84).
+type DiscordComponentMessageSpec = {
+  text?: string;
+  blocks?: Array<{
+    type: "actions";
+    buttons: Array<{
+      label: string;
+      style?: "primary" | "secondary" | "success" | "danger" | "link";
+      callbackData?: string;
+    }>;
+  }>;
+};
+type DiscordComponentBuildResult = {
+  content?: string;
+  components?: unknown[];
+};
+type DiscordSdkModule = {
+  buildDiscordComponentMessage(params: { spec: DiscordComponentMessageSpec }): DiscordComponentBuildResult;
+  editDiscordComponentMessage(
+    to: string,
+    messageId: string,
+    spec: DiscordComponentMessageSpec,
+    opts?: { cfg?: unknown; accountId?: string },
+  ): Promise<{ messageId: string; channelId: string }>;
+  registerBuiltDiscordComponentMessage(params: {
+    buildResult: DiscordComponentBuildResult;
+    messageId: string;
+  }): void;
+  resolveDiscordAccount(params: { cfg: unknown; accountId?: string }): {
+    token?: string;
+  };
+};
+type TelegramAccountSdkModule = {
+  resolveTelegramAccount(params: { cfg: unknown; accountId?: string }): {
+    token?: string;
+  };
+};
 type DiscordExtensionApiModule = {
   resolveDiscordAccount?: (params: { cfg: unknown; accountId?: string }) => {
     token?: string;


### PR DESCRIPTION
## Summary

- Replace `typeof import("openclaw/plugin-sdk/discord")` type aliases with equivalent structural interface types
- jiti resolves those `import()` expressions at load time, which fails on OpenClaw >=2026.4.2 where the subpath exports were removed — the plugin crashes before the runtime compat fallback added in #83 can run
- The runtime loading via `loadOpenClawCompatModule` was already correct; this fix ensures the file can be parsed/loaded in the first place

Fixes #84

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all controller and compat tests pass (1 pre-existing locale-dependent failure in `format.test.ts` unrelated to this change)