### PR TITLE
fix: clear stale Telegram CAS bindings before reuse

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -2429,6 +2429,47 @@ describe("Discord controller flows", () => {
     );
   });
 
+  it("does not restore a dead binding when cas_status applies overrides", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      preferences: {
+        preferredModel: "openai/gpt-5.4",
+        updatedAt: Date.now(),
+      },
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildTelegramCommandContext({
+        args: "--model openai/gpt-5.4-mini",
+        commandBody: "/cas_status --model openai/gpt-5.4-mini",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
+      }),
+    );
+
+    expect(reply).toEqual({
+      text: "Bind this conversation to Codex before changing status settings.",
+    });
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex clearing stale binding"),
+    );
+  });
+
   it("hides the fast button on status controls when the current model does not support it", async () => {
     const { controller, sendMessageTelegram } = await createControllerHarness();
     await (controller as any).store.upsertBinding({

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -2377,6 +2377,58 @@ describe("Discord controller flows", () => {
     expect(buttons[1][1].text).toBe("Permissions: toggle");
   });
 
+  it("clears a dead binding when status reads hit a missing thread", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+    await (controller as any).store.upsertPendingRequest({
+      requestId: "pending-1",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      state: {
+        requestId: "pending-1",
+        options: ["Approve Once", "Cancel"],
+        expiresAt: Date.now() + 60_000,
+      },
+      updatedAt: Date.now(),
+    });
+    const callback = await (controller as any).store.putCallback({
+      kind: "refresh-status",
+      conversation,
+    });
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildTelegramCommandContext({
+        commandBody: "/cas_status",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
+      }),
+    );
+
+    expect(reply.text).toContain("Binding: none");
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
+    expect((controller as any).store.getPendingRequestByConversation(conversation)).toBeNull();
+    expect((controller as any).store.getCallback(callback.token)).toBeNull();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex clearing stale binding"),
+    );
+  });
+
   it("hides the fast button on status controls when the current model does not support it", async () => {
     const { controller, sendMessageTelegram } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
@@ -4841,6 +4893,50 @@ describe("Discord controller flows", () => {
     expect(staleQueueMessage).not.toHaveBeenCalled();
     expect(staleInterrupt).toHaveBeenCalled();
     expect(startTurn).toHaveBeenCalled();
+  });
+
+  it("drops a dead bound thread before starting a new turn", async () => {
+    const { controller, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:chan-1",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+    const startTurn = vi.fn(() => ({
+      result: new Promise(() => {}),
+      getThreadId: () => undefined,
+      queueMessage: vi.fn(async () => true),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    await (controller as any).startTurn({
+      conversation,
+      binding,
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "command",
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: undefined,
+      existingThreadId: undefined,
+    }));
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
   });
 
   it("does not send the plan keepalive after a questionnaire is already visible", async () => {

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -3818,6 +3818,64 @@ describe("Discord controller flows", () => {
     });
   });
 
+  it("clears sibling resume-thread callbacks once a resume selection enters pending approval", async () => {
+    const { controller } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:456",
+      parentConversationId: "123",
+    } as const;
+    const first = await (controller as any).store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+    });
+    const second = await (controller as any).store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-2",
+      workspaceDir: "/repo/openclaw",
+    });
+    const pickerView = await (controller as any).store.putCallback({
+      kind: "picker-view",
+      conversation,
+      view: {
+        mode: "threads",
+        page: 0,
+      },
+    });
+
+    await controller.handleTelegramInteractive({
+      ...conversation,
+      threadId: 456,
+      requestConversationBinding: vi.fn(async () => ({
+        status: "pending" as const,
+        reply: {
+          text: "Plugin bind approval required",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Allow once", callback_data: "pluginbind:approval:o" }]],
+            },
+          },
+        },
+      })),
+      callback: {
+        payload: first.token,
+      },
+      respond: {
+        clearButtons: vi.fn(async () => {}),
+        reply: vi.fn(async () => {}),
+        editMessage: vi.fn(async () => {}),
+      },
+    } as any);
+
+    expect((controller as any).store.getCallback(first.token)).toBeNull();
+    expect((controller as any).store.getCallback(second.token)).toBeNull();
+    expect((controller as any).store.getCallback(pickerView.token)?.kind).toBe("picker-view");
+  });
+
   it("renders Telegram bind approval buttons from interactive reply blocks", async () => {
     const { controller } = await createControllerHarness();
     const callback = await (controller as any).store.putCallback({

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -5038,6 +5038,56 @@ describe("Discord controller flows", () => {
     expect((controller as any).store.getBinding(conversation)).toBeNull();
   });
 
+  it("keeps the saved binding when preflight thread verification fails for a generic error", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:chan-1",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(new Error("rpc timeout"));
+    await (controller as any).store.upsertBinding(binding);
+    const startTurn = vi.fn(() => ({
+      result: new Promise(() => {}),
+      getThreadId: () => undefined,
+      queueMessage: vi.fn(async () => true),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    await (controller as any).startTurn({
+      conversation,
+      binding,
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "command",
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: "session-1",
+      existingThreadId: "thread-1",
+    }));
+    expect((controller as any).store.getBinding(conversation)).toEqual(
+      expect.objectContaining({
+        sessionKey: "session-1",
+        threadId: "thread-1",
+      }),
+    );
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex could not verify bound thread before start turn (command)"),
+    );
+  });
+
   it("does not send the plan keepalive after a questionnaire is already visible", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-23T13:10:00-04:00"));

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -168,6 +168,19 @@ type ActiveRunRecord = {
   handle: ActiveCodexRun;
 };
 
+function isPreMaterializedThreadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.trim().toLowerCase();
+  return (
+    normalized.includes("not materialized yet") ||
+    normalized.includes("includeturns is unavailable before first user message")
+  );
+}
+
+function shouldClearBindingForThreadError(error: unknown): boolean {
+  return isMissingThreadError(error) && !isPreMaterializedThreadError(error);
+}
+
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const TEXT_ATTACHMENT_FILE_EXTENSIONS = new Set([
@@ -2316,6 +2329,18 @@ export class CodexPluginController {
     return getBindingPermissionsMode(binding ?? null);
   }
 
+  private toConversationTarget(
+    conversation: StoredBinding["conversation"] | ConversationTarget,
+  ): ConversationTarget {
+    return {
+      channel: conversation.channel,
+      accountId: conversation.accountId,
+      conversationId: conversation.conversationId,
+      parentConversationId: conversation.parentConversationId,
+      threadId: "threadId" in conversation ? conversation.threadId : undefined,
+    };
+  }
+
   private async waitForActiveRunToClear(
     conversation: ConversationTarget,
     timeoutMs = 3_000,
@@ -2331,6 +2356,40 @@ export class CodexPluginController {
     return !this.activeRuns.has(key);
   }
 
+  private async clearStaleBinding(binding: StoredBinding, reason: string): Promise<void> {
+    const conversation = this.toConversationTarget(binding.conversation);
+    this.api.logger.warn(
+      `codex clearing stale binding ${this.formatConversationForLog(conversation)} thread=${binding.threadId} reason=${reason}`,
+    );
+    await this.unbindConversation(conversation);
+  }
+
+  private async ensureUsableBindingForTurn(
+    binding: StoredBinding | null,
+    reason: string,
+  ): Promise<StoredBinding | null> {
+    if (!binding) {
+      return null;
+    }
+    try {
+      await this.client.readThreadState({
+        profile: this.getPermissionsMode(binding),
+        sessionKey: binding.sessionKey,
+        threadId: binding.threadId,
+      });
+      return binding;
+    } catch (error) {
+      if (!shouldClearBindingForThreadError(error)) {
+        if (isMissingThreadError(error)) {
+          return binding;
+        }
+        throw error;
+      }
+      await this.clearStaleBinding(binding, reason);
+      return null;
+    }
+  }
+
   private async readEffectiveThreadState(binding: StoredBinding): Promise<{
     state: ThreadState | undefined;
     effectiveState: ThreadState | undefined;
@@ -2340,7 +2399,12 @@ export class CodexPluginController {
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
-    }).catch(() => undefined);
+    }).catch(async (error) => {
+      if (shouldClearBindingForThreadError(error)) {
+        await this.clearStaleBinding(binding, "read effective thread state");
+      }
+      return undefined;
+    });
     const desired = buildDesiredThreadConfiguration(state, binding);
     return {
       state,
@@ -2419,7 +2483,12 @@ export class CodexPluginController {
         profile,
         sessionKey: binding.sessionKey,
         threadId: binding.threadId,
-      }).catch(() => undefined));
+      }).catch(async (error) => {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, opts?.context ?? "reconcile thread settings");
+        }
+        return undefined;
+      }));
     let desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
     if (desired.model && desired.model !== state?.model?.trim()) {
       try {
@@ -2431,6 +2500,10 @@ export class CodexPluginController {
         });
         desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} model`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} model: ${String(error)}`,
         );
@@ -2448,6 +2521,10 @@ export class CodexPluginController {
         });
         desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} fast mode`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} fast mode: ${String(error)}`,
         );
@@ -2471,6 +2548,10 @@ export class CodexPluginController {
           sandbox: desired.sandbox,
         });
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} permissions`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} permissions: ${String(error)}`,
         );
@@ -2799,12 +2880,16 @@ export class CodexPluginController {
     bindingActive: boolean,
   ): Promise<StatusCardRender> {
     const text = await this.buildStatusText(conversation, binding, bindingActive);
-    if (!conversation || !binding || !bindingActive) {
+    const currentBinding =
+      binding && conversation
+        ? this.store.getBinding(this.toConversationTarget(binding.conversation))
+        : binding;
+    if (!conversation || !currentBinding || !bindingActive) {
       return { text };
     }
     return {
       text,
-      buttons: await this.buildStatusControlButtons(conversation, binding),
+      buttons: await this.buildStatusControlButtons(conversation, currentBinding),
     };
   }
 
@@ -3488,8 +3573,12 @@ export class CodexPluginController {
     reason: "command" | "inbound" | "plan";
     collaborationMode?: CollaborationMode;
   }): Promise<void> {
+    const binding = await this.ensureUsableBindingForTurn(
+      params.binding,
+      `start turn (${params.reason})`,
+    );
     const key = buildConversationKey(params.conversation);
-    const profile = this.getPermissionsMode(params.binding);
+    const profile = this.getPermissionsMode(binding);
     const existing = this.activeRuns.get(key);
     this.api.logger.debug?.(
       `codex turn request reason=${params.reason} ${this.formatConversationForLog(params.conversation)} workspace=${params.workspaceDir} existing=${existing ? existing.mode : "none"} profile=${profile} prompt="${summarizeTextForLog(params.prompt)}"`,
@@ -3530,21 +3619,21 @@ export class CodexPluginController {
     }
     const typing = await this.startTypingLease(params.conversation);
     this.api.logger.debug?.(
-      `codex turn starting app-server run ${this.formatConversationForLog(params.conversation)} typing=${typing ? "yes" : "no"} session=${params.binding?.sessionKey ?? "<none>"} existingThread=${params.binding?.threadId ?? "<none>"} profile=${profile} mode=${params.collaborationMode?.mode ?? "default"}`,
+      `codex turn starting app-server run ${this.formatConversationForLog(params.conversation)} typing=${typing ? "yes" : "no"} session=${binding?.sessionKey ?? "<none>"} existingThread=${binding?.threadId ?? "<none>"} profile=${profile} mode=${params.collaborationMode?.mode ?? "default"}`,
     );
     const desired = buildDesiredThreadConfiguration(
       undefined,
-      params.binding,
+      binding,
       this.settings.defaultModel,
     );
     const run = this.client.startTurn({
       profile,
-      sessionKey: params.binding?.sessionKey,
+      sessionKey: binding?.sessionKey,
       workspaceDir: params.workspaceDir,
       prompt: params.prompt,
       input: params.input,
       runId: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
-      existingThreadId: params.binding?.threadId,
+      existingThreadId: binding?.threadId,
       model: desired.model,
       reasoningEffort: desired.reasoningEffort,
       serviceTier: desired.serviceTier ?? undefined,
@@ -3584,7 +3673,7 @@ export class CodexPluginController {
           const state = await this.client
             .readThreadState({
               profile,
-              sessionKey: params.binding?.sessionKey,
+              sessionKey: binding?.sessionKey,
               threadId,
             })
             .catch(() => null);
@@ -3615,7 +3704,7 @@ export class CodexPluginController {
         const completionText =
           result.terminalStatus === "failed"
             ? await this.describeTurnFailure({
-            sessionKey: params.binding?.sessionKey,
+            sessionKey: binding?.sessionKey,
             profile,
             error: result.terminalError?.message ?? "turn failed",
             terminalError: result.terminalError,
@@ -3636,7 +3725,7 @@ export class CodexPluginController {
         await this.sendText(
           params.conversation,
           await this.describeTurnFailure({
-            sessionKey: params.binding?.sessionKey,
+            sessionKey: binding?.sessionKey,
             profile,
             error,
           }),
@@ -6452,10 +6541,8 @@ export class CodexPluginController {
       }
     };
 
-    const [initialState, replay] = await Promise.all([
-      readStateForRestore(),
-      readReplayForRestore(),
-    ]);
+    const initialState = await readStateForRestore();
+    const replay = await readReplayForRestore();
     const state =
       (await this.reconcileThreadConfiguration(binding, {
         threadState: initialState,
@@ -6590,7 +6677,12 @@ export class CodexPluginController {
             profile,
             sessionKey: binding.sessionKey,
             threadId: binding.threadId,
-          }).catch(() => undefined)
+          }).catch(async (error) => {
+            if (shouldClearBindingForThreadError(error)) {
+              await this.clearStaleBinding(binding, "build status text");
+            }
+            return undefined;
+          })
         : Promise.resolve(undefined),
       this.client.readAccount({
         profile,
@@ -6602,35 +6694,40 @@ export class CodexPluginController {
       }).catch(() => []),
       this.resolveProjectFolder(binding?.workspaceDir || workspaceDir),
     ]);
-    const effectiveThreadState = buildDesiredThreadConfiguration(threadState, binding).effectiveState;
+    const currentBinding =
+      binding && conversation
+        ? this.store.getBinding(this.toConversationTarget(binding.conversation))
+        : binding;
+    const currentBindingActive = bindingActive && Boolean(currentBinding);
+    const effectiveThreadState = buildDesiredThreadConfiguration(threadState, currentBinding).effectiveState;
     const displayThreadState =
       effectiveThreadState ??
-      (binding
+      (currentBinding
         ? {
-            threadId: binding.threadId,
-            threadName: binding.threadTitle,
-            cwd: binding.workspaceDir,
+            threadId: currentBinding.threadId,
+            threadName: currentBinding.threadTitle,
+            cwd: currentBinding.workspaceDir,
           }
         : undefined);
     const threadNote =
-      binding && !threadState
+      currentBinding && !threadState
         ? "Live thread details are unavailable until Codex materializes the thread, usually after the first user message. Model, reasoning, and fast-mode changes made here are saved as defaults until then."
         : undefined;
     this.api.logger.debug?.(
-      `codex status snapshot bindingActive=${bindingActive ? "yes" : "no"} activeRun=${activeRun?.mode ?? "none"} boundThread=${binding?.threadId ?? "<none>"} raw=${formatThreadStateForLog(threadState)} effective=${formatThreadStateForLog(displayThreadState)} ${formatBindingPreferencesForLog(binding)} threadCwd=${displayThreadState?.cwd?.trim() || "<none>"}`,
+      `codex status snapshot bindingActive=${currentBindingActive ? "yes" : "no"} activeRun=${activeRun?.mode ?? "none"} boundThread=${currentBinding?.threadId ?? "<none>"} raw=${formatThreadStateForLog(threadState)} effective=${formatThreadStateForLog(displayThreadState)} ${formatBindingPreferencesForLog(currentBinding)} threadCwd=${displayThreadState?.cwd?.trim() || "<none>"}`,
     );
 
     return formatCodexStatusText({
       pluginVersion: PLUGIN_VERSION,
       threadState: displayThreadState,
-      bindingThreadTitle: binding?.threadTitle,
+      bindingThreadTitle: currentBinding?.threadTitle,
       account,
       rateLimits: limits,
-      bindingActive,
+      bindingActive: currentBindingActive,
       projectFolder,
-      worktreeFolder: displayThreadState?.cwd?.trim() || binding?.workspaceDir || workspaceDir,
-      contextUsage: binding?.contextUsage,
-      planMode: bindingActive ? activeRun?.mode === "plan" : undefined,
+      worktreeFolder: displayThreadState?.cwd?.trim() || currentBinding?.workspaceDir || workspaceDir,
+      contextUsage: currentBinding?.contextUsage,
+      planMode: currentBindingActive ? activeRun?.mode === "plan" : undefined,
       threadNote,
       permissionNote:
         pendingProfile && activeRun

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2388,10 +2388,10 @@ export class CodexPluginController {
       return binding;
     } catch (error) {
       if (!shouldClearBindingForThreadError(error)) {
-        if (isMissingThreadError(error)) {
-          return binding;
-        }
-        throw error;
+        this.api.logger.warn(
+          `codex could not verify bound thread before ${reason} ${this.formatConversationForLog(this.toConversationTarget(binding.conversation))} thread=${binding.threadId}: ${String(error)}`,
+        );
+        return binding;
       }
       await this.clearStaleBinding(binding, reason);
       return null;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5390,6 +5390,9 @@ export class CodexPluginController {
         responders.requestConversationBinding,
       );
       if (bindResult.status === "pending") {
+        await this.store.removeConversationCallbacks(callback.conversation, {
+          kinds: ["resume-thread"],
+        });
         // Interactive bind requests already send the approval prompt with the
         // channel-specific buttons/components from responders.requestConversationBinding.
         // Sending another plain-text reply here duplicates the same prompt.
@@ -5399,7 +5402,9 @@ export class CodexPluginController {
         await responders.reply(bindResult.message);
         return;
       }
-      await this.store.removeCallback(callback.token);
+      await this.store.removeConversationCallbacks(callback.conversation, {
+        kinds: ["resume-thread"],
+      });
       if (callback.syncTopic) {
         const syncedName = buildResumeTopicName({
           title: threadState?.threadName?.trim() || callback.threadTitle,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2257,7 +2257,15 @@ export class CodexPluginController {
       if (!binding || !conversation) {
         return { text: "Bind this conversation to Codex before changing status settings." };
       }
-      const { state: currentThreadState, effectiveState } = await this.readEffectiveThreadState(binding);
+      const {
+        binding: currentBinding,
+        state: currentThreadState,
+        effectiveState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        return { text: "Bind this conversation to Codex before changing status settings." };
+      }
+      binding = currentBinding;
       const effectiveModel =
         parsed.requestedModel?.trim() ||
         (await this.resolveCurrentModelHint(binding, effectiveState));
@@ -2391,10 +2399,12 @@ export class CodexPluginController {
   }
 
   private async readEffectiveThreadState(binding: StoredBinding): Promise<{
+    binding: StoredBinding | null;
     state: ThreadState | undefined;
     effectiveState: ThreadState | undefined;
   }> {
     const profile = this.getPermissionsMode(binding);
+    let bindingCleared = false;
     const state = await this.client.readThreadState({
       profile,
       sessionKey: binding.sessionKey,
@@ -2402,11 +2412,16 @@ export class CodexPluginController {
     }).catch(async (error) => {
       if (shouldClearBindingForThreadError(error)) {
         await this.clearStaleBinding(binding, "read effective thread state");
+        bindingCleared = true;
       }
       return undefined;
     });
-    const desired = buildDesiredThreadConfiguration(state, binding);
+    const currentBinding =
+      this.store.getBinding(this.toConversationTarget(binding.conversation)) ??
+      (bindingCleared ? null : binding);
+    const desired = buildDesiredThreadConfiguration(state, currentBinding);
     return {
+      binding: currentBinding,
       state,
       effectiveState: desired.effectiveState,
     };
@@ -2564,10 +2579,13 @@ export class CodexPluginController {
     conversation: ConversationTarget,
     binding: StoredBinding,
   ): Promise<PluginInteractiveButtons> {
-    const { effectiveState } = await this.readEffectiveThreadState(binding);
-    const currentModel = await this.resolveCurrentModelHint(binding, effectiveState);
+    const { binding: currentBinding, effectiveState } = await this.readEffectiveThreadState(binding);
+    if (!currentBinding) {
+      return [];
+    }
+    const currentModel = await this.resolveCurrentModelHint(currentBinding, effectiveState);
     const currentReasoning = normalizeReasoningEffort(
-      effectiveState?.reasoningEffort ?? binding.preferences?.preferredReasoningEffort,
+      effectiveState?.reasoningEffort ?? currentBinding.preferences?.preferredReasoningEffort,
     );
     const [showModelPicker, showReasoningPicker, togglePermissions, compactThread, stopRun, refreshStatus, detachThread, showSkills, showMcp] = await Promise.all([
       this.store.putCallback({
@@ -3281,8 +3299,16 @@ export class CodexPluginController {
     if (typeof action === "object") {
       return { text: action.error };
     }
+    const {
+      binding: currentBinding,
+      state: threadState,
+      effectiveState,
+    } = await this.readEffectiveThreadState(binding);
+    if (!currentBinding) {
+      return { text: "Bind this conversation to a Codex thread before toggling fast mode." };
+    }
+    binding = currentBinding;
     const profile = this.getPermissionsMode(binding);
-    const { state: threadState, effectiveState } = await this.readEffectiveThreadState(binding);
     const currentModel =
       effectiveState?.model?.trim() || binding.preferences?.preferredModel?.trim() || undefined;
     if (!modelSupportsFast(currentModel)) {
@@ -5559,9 +5585,17 @@ export class CodexPluginController {
         await responders.reply("No Codex binding for this conversation.");
         return;
       }
-      const profile = this.getPermissionsMode(binding);
-      const { state: threadState, effectiveState } = await this.readEffectiveThreadState(binding);
-      const currentModel = await this.resolveCurrentModelHint(binding, effectiveState);
+      const {
+        binding: currentBinding,
+        state: threadState,
+        effectiveState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
+      const profile = this.getPermissionsMode(currentBinding);
+      const currentModel = await this.resolveCurrentModelHint(currentBinding, effectiveState);
       if (!modelSupportsFast(currentModel)) {
         await responders.reply(
           `Fast mode is unavailable for ${currentModel ?? "the current model"}. Use a GPT-5.4+ model to enable it.`,
@@ -5576,8 +5610,8 @@ export class CodexPluginController {
       if (threadState) {
         updatedState = await this.client.setThreadServiceTier({
           profile,
-          sessionKey: binding.sessionKey,
-          threadId: binding.threadId,
+          sessionKey: currentBinding.sessionKey,
+          threadId: currentBinding.threadId,
           serviceTier: nextTier,
         }).catch((error) => {
           if (isMissingThreadError(error)) {
@@ -5588,9 +5622,9 @@ export class CodexPluginController {
       }
       const preferredServiceTier = preferredServiceTierFromRequest(nextTier);
       const updatedBinding: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         preferences: {
-          ...(binding.preferences ?? {
+          ...(currentBinding.preferences ?? {
             preferredServiceTier: null,
             updatedAt: Date.now(),
           }),
@@ -5725,9 +5759,16 @@ export class CodexPluginController {
         return;
       }
       const active = this.activeRuns.get(buildConversationKey(callback.conversation));
-      const { state: currentThreadState } = await this.readEffectiveThreadState(binding);
+      const {
+        binding: currentBinding,
+        state: currentThreadState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
       const updatedBindingBase: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         permissionsMode: active ? currentProfile : nextProfile,
         pendingPermissionsMode: active ? nextProfile : undefined,
         updatedAt: Date.now(),
@@ -6001,14 +6042,18 @@ export class CodexPluginController {
         await responders.reply("No Codex binding for this conversation.");
         return;
       }
-      const profile = this.getPermissionsMode(binding);
-      const { state: threadState } = await this.readEffectiveThreadState(binding);
+      const { binding: currentBinding, state: threadState } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
+      const profile = this.getPermissionsMode(currentBinding);
       let state = threadState;
       if (threadState) {
         state = await this.client.setThreadModel({
           profile,
-          sessionKey: binding.sessionKey,
-          threadId: binding.threadId,
+          sessionKey: currentBinding.sessionKey,
+          threadId: currentBinding.threadId,
           model: callback.model,
         }).catch((error) => {
           if (isMissingThreadError(error)) {
@@ -6018,23 +6063,23 @@ export class CodexPluginController {
         });
       }
       const nextPreferredServiceTier = modelSupportsFast(callback.model)
-        ? binding.preferences?.preferredServiceTier ?? null
+        ? currentBinding.preferences?.preferredServiceTier ?? null
         : "default";
       let nextState = state;
       if (!modelSupportsFast(callback.model) && normalizeServiceTier(state?.serviceTier) === "fast") {
         nextState = await this.client
           .setThreadServiceTier({
             profile,
-            sessionKey: binding.sessionKey,
-            threadId: binding.threadId,
+            sessionKey: currentBinding.sessionKey,
+            threadId: currentBinding.threadId,
             serviceTier: null,
           })
           .catch(() => ({ ...state, serviceTier: "default" } as ThreadState));
       }
       const updatedBinding: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         preferences: {
-          ...(binding.preferences ?? {
+          ...(currentBinding.preferences ?? {
             preferredServiceTier: null,
             updatedAt: Date.now(),
           }),

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -367,4 +367,56 @@ describe("state store", () => {
       updatedAt: pendingBindUpdatedAt,
     });
   });
+
+  it("removes matching conversation callbacks without touching other kinds", async () => {
+    const store = await makeStore();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:456",
+      parentConversationId: "123",
+    } as const;
+    const otherConversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:789",
+      parentConversationId: "123",
+    } as const;
+    const resumeA = await store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+    });
+    const resumeB = await store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-2",
+      workspaceDir: "/tmp/work",
+    });
+    const pickerView = await store.putCallback({
+      kind: "picker-view",
+      conversation,
+      view: {
+        mode: "threads",
+        includeAll: false,
+        page: 0,
+      },
+    });
+    const otherResume = await store.putCallback({
+      kind: "resume-thread",
+      conversation: otherConversation,
+      threadId: "thread-3",
+      workspaceDir: "/tmp/other",
+    });
+
+    await store.removeConversationCallbacks(conversation, {
+      kinds: ["resume-thread"],
+    });
+
+    expect(store.getCallback(resumeA.token)).toBeNull();
+    expect(store.getCallback(resumeB.token)).toBeNull();
+    expect(store.getCallback(pickerView.token)?.kind).toBe("picker-view");
+    expect(store.getCallback(otherResume.token)?.kind).toBe("resume-thread");
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -683,6 +683,30 @@ export class PluginStateStore {
     this.snapshot.callbacks = this.snapshot.callbacks.filter((entry) => entry.token !== token);
     await this.save();
   }
+
+  async removeConversationCallbacks(
+    conversation: ConversationTarget,
+    params?: {
+      kinds?: CallbackAction["kind"][];
+      excludeToken?: string;
+    },
+  ): Promise<void> {
+    const conversationKey = toConversationKey(conversation);
+    const allowedKinds = params?.kinds ? new Set(params.kinds) : null;
+    this.snapshot.callbacks = this.snapshot.callbacks.filter((entry) => {
+      if (params?.excludeToken && entry.token === params.excludeToken) {
+        return true;
+      }
+      if (toConversationKey(entry.conversation) !== conversationKey) {
+        return true;
+      }
+      if (allowedKinds && !allowedKinds.has(entry.kind)) {
+        return true;
+      }
+      return false;
+    });
+    await this.save();
+  }
 }
 
 export function buildPluginSessionKey(threadId: string): string {


### PR DESCRIPTION
Fixes #94.

## What
- clear a saved CAS binding when a status read or a new turn discovers that the bound thread is no longer usable
- stop `cas_status` and turn startup from restoring a binding that was already cleared during that check
- remove sibling `resume-thread` callbacks for the same conversation once one resume choice moves into approval or succeeds

## Why
A resumed Telegram topic could still look bound and yet behave like it was dead. In the April 11 case, the thread itself was still resumable. What had drifted was the binding state around it.

That showed up in two places:
- stale bindings could survive status reads and turn setup longer than they should
- repeated `/cas_resume` attempts could leave old resume callbacks behind for the same topic

This patch cleans up both parts. It keeps the controller from reusing dead bindings, and it clears old resume choices once a topic starts binding again.

## Tests
- `pnpm test src/controller.test.ts`
- `pnpm test src/state.test.ts`
- `pnpm typecheck`
- `pnpm test`

## AI Assistance
I used Codex to inspect local gateway and plugin state, trace the binding lifecycle, implement the fix, and run the tests above.
