### PR TITLE
fix: keep pending-input runs alive until callbacks settle

### DIFF
--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -5021,6 +5021,76 @@ describe("Discord controller flows", () => {
     expect(reply).toHaveBeenCalledWith({
       text: "Recorded your answers and sent them to Codex.",
     });
+    expect((controller as any).activeRuns.get(activeKey)).toBeUndefined();
+    expect((controller as any).store.getPendingRequestById("req-plan-race")).toBeNull();
+  });
+
+  it("ignores late questionnaire input from an older run when a newer run is already active", async () => {
+    const { controller } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: TEST_TELEGRAM_PEER_ID,
+    } as const;
+    const activeKey = `telegram::default::${TEST_TELEGRAM_PEER_ID}::`;
+    const newerRun = {
+      getThreadId: () => "thread-new",
+      queueMessage: vi.fn(async () => false),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    };
+    const olderRun = {
+      getThreadId: () => "thread-old",
+      queueMessage: vi.fn(async () => false),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    };
+
+    (controller as any).activeRuns.set(activeKey, {
+      conversation,
+      workspaceDir: "/repo/new",
+      mode: "plan",
+      profile: "default",
+      handle: newerRun,
+    });
+
+    await (controller as any).handlePendingInputState(
+      conversation,
+      "/repo/old",
+      "plan",
+      "default",
+      {
+        requestId: "req-old-run",
+        options: [],
+        expiresAt: Date.now() + 7 * 24 * 60 * 60_000,
+        method: "item/tool/requestUserInput",
+        questionnaire: {
+          currentIndex: 0,
+          questions: [
+            {
+              index: 0,
+              id: "breakfast",
+              header: "Breakfast",
+              prompt: "Do you like cereal?",
+              options: [
+                { key: "A", label: "Yes", description: "Choose yes." },
+              ],
+              guidance: [],
+            },
+          ],
+          answers: [null],
+          responseMode: "structured",
+        },
+      },
+      olderRun as any,
+    );
+
+    expect((controller as any).activeRuns.get(activeKey)?.handle).toBe(newerRun);
+    expect((controller as any).store.getPendingRequestById("req-old-run")).toBeNull();
   });
 
   it("tells the user to log back in when Codex reports OpenAI auth is required", async () => {

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -4850,6 +4850,7 @@ describe("Discord controller flows", () => {
       const harness = await createControllerHarness();
       const { controller } = harness;
       const { sendMessageTelegram } = harness;
+      const activeKey = `telegram::default::${TEST_TELEGRAM_PEER_ID}::`;
       let resolveResult: ((value: unknown) => void) | undefined;
       const result = new Promise((resolve) => {
         resolveResult = resolve;
@@ -4925,9 +4926,101 @@ describe("Discord controller flows", () => {
       });
       await Promise.resolve();
       await Promise.resolve();
+      expect((controller as any).activeRuns.get(activeKey)?.mode).toBe("plan");
+      expect((controller as any).store.getPendingRequestById("req-plan-1")).not.toBeNull();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("restores the active plan run when questionnaire input arrives after result cleanup", async () => {
+    const { controller } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: TEST_TELEGRAM_PEER_ID,
+    } as const;
+    const activeKey = `telegram::default::${TEST_TELEGRAM_PEER_ID}::`;
+    let onPendingInput: ((state: any) => Promise<void>) | undefined;
+    const submitPendingInputPayload = vi.fn(async () => true);
+    (controller as any).client.startTurn = vi.fn((params: any) => {
+      onPendingInput = params.onPendingInput;
+      return {
+        result: Promise.resolve({ threadId: "thread-1" }),
+        getThreadId: () => "thread-1",
+        queueMessage: vi.fn(async () => false),
+        interrupt: vi.fn(async () => {}),
+        isAwaitingInput: () => false,
+        submitPendingInput: vi.fn(async () => false),
+        submitPendingInputPayload,
+      };
+    });
+
+    await (controller as any).startPlan({
+      conversation,
+      binding: null,
+      workspaceDir: "/repo/openclaw",
+      prompt: "Ask the breakfast question.",
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    (controller as any).activeRuns.delete(activeKey);
+    expect((controller as any).activeRuns.get(activeKey)).toBeUndefined();
+
+    await onPendingInput?.({
+      requestId: "req-plan-race",
+      options: [],
+      expiresAt: Date.now() + 7 * 24 * 60 * 60_000,
+      method: "item/tool/requestUserInput",
+      questionnaire: {
+        currentIndex: 0,
+        questions: [
+          {
+            index: 0,
+            id: "breakfast",
+            header: "Breakfast",
+            prompt: "Do you like cereal?",
+            options: [
+              { key: "A", label: "Yes", description: "Choose yes." },
+            ],
+            guidance: [],
+          },
+        ],
+        answers: [null],
+        responseMode: "structured",
+      },
+    });
+
+    expect((controller as any).activeRuns.get(activeKey)?.mode).toBe("plan");
+    const callback = (controller as any).store.snapshot.callbacks.find((entry: any) =>
+      entry.kind === "pending-questionnaire" &&
+      entry.requestId === "req-plan-race" &&
+      entry.action === "select"
+    );
+    expect(callback).toBeTruthy();
+    const reply = vi.fn(async () => {});
+
+    await controller.handleTelegramInteractive({
+      ...conversation,
+      callback: {
+        payload: callback.token,
+      },
+      respond: {
+        clearButtons: vi.fn(async () => {}),
+        reply,
+        editMessage: vi.fn(async () => {}),
+      },
+    } as any);
+
+    expect(submitPendingInputPayload).toHaveBeenCalledWith({
+      answers: {
+        breakfast: { answers: ["Yes"] },
+      },
+    });
+    expect(reply).toHaveBeenCalledWith({
+      text: "Recorded your answers and sent them to Codex.",
+    });
   });
 
   it("tells the user to log back in when Codex reports OpenAI auth is required", async () => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -166,6 +166,7 @@ type ActiveRunRecord = {
   mode: "default" | "plan" | "review";
   profile: PermissionsMode;
   handle: ActiveCodexRun;
+  cleanupWhenInputSettles?: boolean;
 };
 
 const execFileAsync = promisify(execFile);
@@ -2331,6 +2332,66 @@ export class CodexPluginController {
     return !this.activeRuns.has(key);
   }
 
+  private ensureActiveRunRegistration(params: {
+    conversation: ConversationTarget;
+    workspaceDir: string;
+    mode: ActiveRunRecord["mode"];
+    profile: PermissionsMode;
+    run: ActiveCodexRun;
+    reason: string;
+  }): boolean {
+    const key = buildConversationKey(params.conversation);
+    const active = this.activeRuns.get(key);
+    if (active?.handle === params.run) {
+      return true;
+    }
+    if (active && active.handle !== params.run) {
+      this.api.logger.warn(
+        `codex ignoring ${params.reason} for stale run ${this.formatConversationForLog(params.conversation)} activeMode=${active.mode} incomingMode=${params.mode}`,
+      );
+      return false;
+    }
+    this.activeRuns.set(key, {
+      conversation: params.conversation,
+      workspaceDir: params.workspaceDir,
+      mode: params.mode,
+      profile: params.profile,
+      handle: params.run,
+    });
+    this.api.logger.warn(
+      `codex restored active run from ${params.reason} ${this.formatConversationForLog(params.conversation)} mode=${params.mode}`,
+    );
+    return true;
+  }
+
+  private async finalizeActiveRun(
+    conversation: ConversationTarget,
+    run: ActiveCodexRun,
+    reason: string,
+  ): Promise<void> {
+    const key = buildConversationKey(conversation);
+    const active = this.activeRuns.get(key);
+    if (!active || active.handle !== run) {
+      this.api.logger.debug?.(
+        `codex skipped active run cleanup ${this.formatConversationForLog(conversation)} reason=${reason} active=${active ? "other-run" : "none"}`,
+      );
+      return;
+    }
+    const pending = this.store.getPendingRequestByConversation(conversation);
+    const awaitingInput = typeof run.isAwaitingInput === "function" && run.isAwaitingInput();
+    if (awaitingInput || pending) {
+      active.cleanupWhenInputSettles = true;
+      this.api.logger.debug?.(
+        `codex deferred active run cleanup ${this.formatConversationForLog(conversation)} reason=${reason} awaitingInput=${awaitingInput ? "yes" : "no"} pendingRequest=${pending?.requestId ?? "none"}`,
+      );
+      return;
+    }
+    this.activeRuns.delete(key);
+    await this.applyPendingBindingPermissionsModeMigration(conversation);
+    this.api.logger.debug?.(
+      `codex cleaned up active run ${this.formatConversationForLog(conversation)} reason=${reason}`,
+    );
+  }
   private async readEffectiveThreadState(binding: StoredBinding): Promise<{
     state: ThreadState | undefined;
     effectiveState: ThreadState | undefined;
@@ -3555,7 +3616,14 @@ export class CodexPluginController {
         this.api.logger.debug?.(
           `codex turn pending input ${state ? "received" : "cleared"} ${this.formatConversationForLog(params.conversation)} questionnaire=${state?.questionnaire ? "yes" : "no"}`,
         );
-        await this.handlePendingInputState(params.conversation, params.workspaceDir, state, run);
+        await this.handlePendingInputState(
+          params.conversation,
+          params.workspaceDir,
+          params.collaborationMode?.mode === "plan" ? "plan" : "default",
+          profile,
+          state,
+          run,
+        );
       },
       onFileEdits: async (text) => {
         await this.sendText(params.conversation, text);
@@ -3644,15 +3712,7 @@ export class CodexPluginController {
       })
       .finally(async () => {
         typing?.stop();
-        this.activeRuns.delete(key);
-        const pending = this.store.getPendingRequestByConversation(params.conversation);
-        if (pending) {
-          await this.store.removePendingRequest(pending.requestId);
-        }
-        await this.applyPendingBindingPermissionsModeMigration(params.conversation);
-        this.api.logger.debug?.(
-          `codex turn cleaned up ${this.formatConversationForLog(params.conversation)}`,
-        );
+        await this.finalizeActiveRun(params.conversation, run, "turn settled");
       });
   }
 
@@ -3816,7 +3876,14 @@ export class CodexPluginController {
         this.api.logger.debug(
           `codex plan pending input ${state ? `received (questionnaire=${state.questionnaire ? "yes" : "no"})` : "cleared"}`,
         );
-        await this.handlePendingInputState(params.conversation, params.workspaceDir, state, run);
+        await this.handlePendingInputState(
+          params.conversation,
+          params.workspaceDir,
+          "plan",
+          profile,
+          state,
+          run,
+        );
       },
       onInterrupted: async () => {
         await this.sendText(params.conversation, formatInterruptedText("plan"));
@@ -3917,12 +3984,7 @@ export class CodexPluginController {
       .finally(async () => {
         stopProgressTimer();
         typing?.stop();
-        this.activeRuns.delete(key);
-        const pending = this.store.getPendingRequestByConversation(params.conversation);
-        if (pending) {
-          await this.store.removePendingRequest(pending.requestId);
-        }
-        await this.applyPendingBindingPermissionsModeMigration(params.conversation);
+        await this.finalizeActiveRun(params.conversation, run, "plan settled");
       });
   }
 
@@ -3993,7 +4055,14 @@ export class CodexPluginController {
         if (state) {
           stopProgressTimer();
         }
-        await this.handlePendingInputState(params.conversation, params.workspaceDir, state, run);
+        await this.handlePendingInputState(
+          params.conversation,
+          params.workspaceDir,
+          "review",
+          profile,
+          state,
+          run,
+        );
       },
       onInterrupted: async () => {
         await this.sendText(params.conversation, "Codex review stopped.");
@@ -4080,25 +4149,38 @@ export class CodexPluginController {
       .finally(async () => {
         stopProgressTimer();
         typing?.stop();
-        this.activeRuns.delete(key);
-        const pending = this.store.getPendingRequestByConversation(params.conversation);
-        if (pending) {
-          await this.store.removePendingRequest(pending.requestId);
-        }
-        await this.applyPendingBindingPermissionsModeMigration(params.conversation);
+        await this.finalizeActiveRun(params.conversation, run, "review settled");
       });
   }
 
   private async handlePendingInputState(
     conversation: ConversationTarget,
     workspaceDir: string,
+    mode: ActiveRunRecord["mode"],
+    profile: PermissionsMode,
     state: PendingInputState | null,
     run: ActiveCodexRun,
   ): Promise<void> {
+    if (state) {
+      if (!this.ensureActiveRunRegistration({
+        conversation,
+        workspaceDir,
+        mode,
+        profile,
+        run,
+        reason: "pending input",
+      })) {
+        return;
+      }
+    }
     if (!state) {
       const existing = this.store.getPendingRequestByConversation(conversation);
       if (existing) {
         await this.store.removePendingRequest(existing.requestId);
+      }
+      const active = this.activeRuns.get(buildConversationKey(conversation));
+      if (active?.handle === run && active.cleanupWhenInputSettles) {
+        await this.finalizeActiveRun(conversation, run, "pending input settled");
       }
       return;
     }
@@ -5308,6 +5390,9 @@ export class CodexPluginController {
       }
       const active = this.activeRuns.get(buildConversationKey(callback.conversation));
       if (!active) {
+        this.api.logger.warn(
+          `codex pending-input callback missing active run ${this.formatConversationForLog(callback.conversation)} requestId=${callback.requestId} pendingRequest=${pending.requestId} thread=${pending.threadId || "<none>"}`,
+        );
         await responders.reply("No active Codex run is waiting for input.");
         return;
       }
@@ -5331,6 +5416,9 @@ export class CodexPluginController {
       }
       const active = this.activeRuns.get(buildConversationKey(callback.conversation));
       if (!active) {
+        this.api.logger.warn(
+          `codex questionnaire callback missing active run ${this.formatConversationForLog(callback.conversation)} requestId=${callback.requestId} pendingRequest=${pending.requestId} thread=${pending.threadId || "<none>"}`,
+        );
         await responders.reply("No active Codex run is waiting for input.");
         return;
       }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1363,6 +1363,7 @@ export class CodexPluginController {
   private readonly settings;
   private readonly client;
   private readonly activeRuns = new Map<string, ActiveRunRecord>();
+  private readonly settledRuns = new WeakSet<ActiveCodexRun>();
   private readonly threadChangesCache = new Map<string, Promise<boolean | undefined>>();
   private readonly store;
   private serviceWorkspaceDir?: string;
@@ -2357,11 +2358,27 @@ export class CodexPluginController {
       mode: params.mode,
       profile: params.profile,
       handle: params.run,
+      cleanupWhenInputSettles: this.settledRuns.has(params.run),
     });
     this.api.logger.warn(
       `codex restored active run from ${params.reason} ${this.formatConversationForLog(params.conversation)} mode=${params.mode}`,
     );
     return true;
+  }
+
+  private async maybeCleanupSettledInteractiveRun(
+    conversation: ConversationTarget,
+    run: ActiveCodexRun,
+    reason: string,
+  ): Promise<void> {
+    const active = this.activeRuns.get(buildConversationKey(conversation));
+    if (!active || active.handle !== run || !active.cleanupWhenInputSettles) {
+      return;
+    }
+    if (this.store.getPendingRequestByConversation(conversation)) {
+      return;
+    }
+    await this.finalizeActiveRun(conversation, run, reason);
   }
 
   private async finalizeActiveRun(
@@ -3712,6 +3729,7 @@ export class CodexPluginController {
       })
       .finally(async () => {
         typing?.stop();
+        this.settledRuns.add(run);
         await this.finalizeActiveRun(params.conversation, run, "turn settled");
       });
   }
@@ -3984,6 +4002,7 @@ export class CodexPluginController {
       .finally(async () => {
         stopProgressTimer();
         typing?.stop();
+        this.settledRuns.add(run);
         await this.finalizeActiveRun(params.conversation, run, "plan settled");
       });
   }
@@ -4149,6 +4168,7 @@ export class CodexPluginController {
       .finally(async () => {
         stopProgressTimer();
         typing?.stop();
+        this.settledRuns.add(run);
         await this.finalizeActiveRun(params.conversation, run, "review settled");
       });
   }
@@ -4178,10 +4198,7 @@ export class CodexPluginController {
       if (existing) {
         await this.store.removePendingRequest(existing.requestId);
       }
-      const active = this.activeRuns.get(buildConversationKey(conversation));
-      if (active?.handle === run && active.cleanupWhenInputSettles) {
-        await this.finalizeActiveRun(conversation, run, "pending input settled");
-      }
+      await this.maybeCleanupSettledInteractiveRun(conversation, run, "pending input settled");
       return;
     }
     if (state.questionnaire) {
@@ -4392,6 +4409,11 @@ export class CodexPluginController {
         return false;
       }
       await this.store.removePendingRequest(pending.requestId);
+      await this.maybeCleanupSettledInteractiveRun(
+        conversation,
+        run,
+        "questionnaire submitted",
+      );
       await this.sendText(conversation, "Recorded your answers and sent them to Codex.");
       return true;
     }
@@ -5501,6 +5523,11 @@ export class CodexPluginController {
         }
         await responders.clear().catch(() => undefined);
         await this.store.removePendingRequest(pending.requestId);
+        await this.maybeCleanupSettledInteractiveRun(
+          callback.conversation,
+          active.handle,
+          "questionnaire submitted",
+        );
         if (callback.conversation.channel !== "discord") {
           await responders.reply("Recorded your answers and sent them to Codex.");
         }


### PR DESCRIPTION
What
- keeps active runs registered while pending input still exists
- restores an active run if questionnaire input arrives after the original settle path
- adds lifecycle logs for deferred cleanup and callback misses

Why
The first questionnaire prompt could be shown to the user, then fail on submission because the run had already been cleaned up. This branch fixes that race, but the work was later folded into #95 with broader follow-up coverage.

Tests
- pnpm test src/controller.test.ts
- pnpm typecheck
- pnpm test

AI Assistance
- Codex used for implementation and testing.
