### PR TITLE
feat: add multi-endpoint CAS support with per-conversation endpoint selection

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,6 +41,53 @@
         "type": "number",
         "minimum": 100
       },
+      "defaultEndpoint": {
+        "type": "string"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "transport": {
+              "type": "string",
+              "enum": [
+                "stdio",
+                "websocket"
+              ]
+            },
+            "command": {
+              "type": "string"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "url": {
+              "type": "string"
+            },
+            "authToken": {
+              "type": "string"
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "requestTimeoutMs": {
+              "type": "number",
+              "minimum": 100
+            }
+          }
+        }
+      },
       "inputTimeoutMs": {
         "type": "number",
         "minimum": 1000
@@ -84,6 +131,14 @@
     },
     "requestTimeoutMs": {
       "label": "Request Timeout (ms)",
+      "advanced": true
+    },
+    "defaultEndpoint": {
+      "label": "Default Endpoint",
+      "advanced": true
+    },
+    "endpoints": {
+      "label": "Endpoints",
       "advanced": true
     },
     "inputTimeoutMs": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,9 +18,9 @@ import {
   type ExperimentalFeatureSummary,
   type McpServerSummary,
   type ModelSummary,
+  type EndpointSettings,
   type PendingInputAction,
   type PendingInputState,
-  type PluginSettings,
   type PermissionsMode,
   type RateLimitSummary,
   type ReviewResult,
@@ -83,7 +83,7 @@ const TURN_INTERRUPT_METHODS = ["turn/interrupt"] as const;
 const execFileAsync = promisify(execFile);
 
 type StartupProbeInfo = {
-  transport: PluginSettings["transport"];
+  transport: EndpointSettings["transport"];
   command?: string;
   args?: string[];
   resolvedCommandPath?: string;
@@ -91,6 +91,8 @@ type StartupProbeInfo = {
   serverName?: string;
   serverVersion?: string;
 };
+
+type ClientEndpointSettings = EndpointSettings & { enabled?: boolean };
 
 type FileEditSummary = {
   path: string;
@@ -823,7 +825,7 @@ async function dispatchJsonRpcEnvelope(
 }
 
 function createJsonRpcClient(
-  settings: PluginSettings,
+  settings: ClientEndpointSettings,
   logger?: PluginLogger,
   onClose?: JsonRpcCloseHandler,
 ): JsonRpcClient {
@@ -890,7 +892,7 @@ async function resolveCommandPath(command: string): Promise<string | undefined> 
   }
 }
 
-async function probeStdioVersion(settings: PluginSettings): Promise<{
+async function probeStdioVersion(settings: ClientEndpointSettings): Promise<{
   resolvedCommandPath?: string;
   cliVersion?: string;
 }> {
@@ -1560,7 +1562,7 @@ function extractFileChangePathsFromReadResult(
 
 async function readFileChangePathsWithClient(params: {
   client: JsonRpcClient;
-  settings: PluginSettings;
+  settings: EndpointSettings;
   threadId: string;
   itemId: string;
   workspaceDir?: string;
@@ -2417,7 +2419,7 @@ export function isMissingThreadError(error: unknown): boolean {
   );
 }
 
-function buildFullAccessPluginSettings(settings: PluginSettings): PluginSettings | null {
+function buildFullAccessPluginSettings(settings: ClientEndpointSettings): ClientEndpointSettings | null {
   if (settings.transport !== "stdio") {
     return null;
   }
@@ -2445,7 +2447,7 @@ export class CodexAppServerClient {
   private readonly requestListeners = new Set<RequestListener>();
 
   constructor(
-    private readonly settings: PluginSettings,
+    private readonly settings: ClientEndpointSettings,
     private readonly logger: PluginLogger,
   ) {}
 
@@ -2538,7 +2540,7 @@ export class CodexAppServerClient {
     params: { sessionKey?: string },
     callback: (args: {
       client: JsonRpcClient;
-      settings: PluginSettings;
+      settings: EndpointSettings;
       initializeResult: unknown;
     }) => Promise<T>,
   ): Promise<T> {
@@ -3768,7 +3770,7 @@ export class CodexAppServerModeClient {
   private readonly clients: Record<PermissionsMode, CodexAppServerClient | null>;
 
   constructor(
-    settings: PluginSettings,
+    settings: ClientEndpointSettings,
     logger: PluginLogger,
   ) {
     const fullAccessSettings = buildFullAccessPluginSettings(settings);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,7 @@ export const COMMANDS = [
   ["cas_mcp", "List Codex MCP servers."],
   ["cas_fast", "Toggle or inspect fast mode for the current Codex binding."],
   ["cas_model", "List or switch the Codex model for the current binding."],
+  ["cas_endpoint", "Show or switch the active Codex endpoint for this conversation."],
   ["cas_permissions", "Show Codex permissions and account status."],
   ["cas_init", "Forward /init to Codex."],
   ["cas_diff", "Forward /diff to Codex."],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { PluginSettings } from "./types.js";
+import type { EndpointSettings, PluginSettings } from "./types.js";
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
 } from "./types.js";
@@ -43,6 +43,14 @@ function readHeaders(record: Record<string, unknown>): Record<string, string> | 
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+function normalizeEndpointId(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed.replace(/\s+/g, "-");
+}
+
 function readNumber(
   record: Record<string, unknown>,
   key: string,
@@ -58,27 +66,69 @@ function readNumber(
 
 export function resolvePluginSettings(rawConfig: unknown): PluginSettings {
   const record = asRecord(rawConfig);
-  const transport = record.transport === "websocket" ? "websocket" : "stdio";
-  const authToken = readString(record, "authToken");
-  const configuredHeaders = readHeaders(record);
-  const headers = {
-    ...(configuredHeaders ?? {}),
-    ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+  const endpointRecords = Array.isArray(record.endpoints)
+    ? record.endpoints
+        .map((entry) => asRecord(entry))
+        .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    : [];
+
+  const parseEndpoint = (entry: Record<string, unknown>, index: number): EndpointSettings => {
+    const transport = entry.transport === "websocket" ? "websocket" : "stdio";
+    const authToken = readString(entry, "authToken");
+    const configuredHeaders = readHeaders(entry);
+    const headers = {
+      ...(configuredHeaders ?? {}),
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    };
+    const fallbackId = index === 0 ? "default" : `endpoint-${index + 1}`;
+    return {
+      id: normalizeEndpointId(readString(entry, "id"), fallbackId),
+      transport,
+      command: readString(entry, "command") ?? "codex",
+      args: readStringArray(entry, "args"),
+      url: readString(entry, "url"),
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      requestTimeoutMs: readNumber(entry, "requestTimeoutMs", DEFAULT_REQUEST_TIMEOUT_MS, 100),
+    };
   };
+
+  const legacyTransport: EndpointSettings["transport"] =
+    record.transport === "websocket" ? "websocket" : "stdio";
+  const legacyAuthToken = readString(record, "authToken");
+  const legacyConfiguredHeaders = readHeaders(record);
+  const legacyHeaders = {
+    ...(legacyConfiguredHeaders ?? {}),
+    ...(legacyAuthToken ? { Authorization: `Bearer ${legacyAuthToken}` } : {}),
+  };
+
+  const endpoints =
+    endpointRecords.length > 0
+      ? endpointRecords.map(parseEndpoint)
+      : [
+          {
+            id: "default",
+            transport: legacyTransport,
+            command: readString(record, "command") ?? "codex",
+            args: readStringArray(record, "args"),
+            url: readString(record, "url"),
+            headers: Object.keys(legacyHeaders).length > 0 ? legacyHeaders : undefined,
+            requestTimeoutMs: readNumber(
+              record,
+              "requestTimeoutMs",
+              DEFAULT_REQUEST_TIMEOUT_MS,
+              100,
+            ),
+          },
+        ];
+
+  const requestedDefaultEndpoint = readString(record, "defaultEndpoint");
+  const defaultEndpoint =
+    endpoints.find((entry) => entry.id === requestedDefaultEndpoint)?.id ?? endpoints[0]?.id ?? "default";
 
   return {
     enabled: record.enabled !== false,
-    transport,
-    command: readString(record, "command") ?? "codex",
-    args: readStringArray(record, "args"),
-    url: readString(record, "url"),
-    headers: Object.keys(headers).length > 0 ? headers : undefined,
-    requestTimeoutMs: readNumber(
-      record,
-      "requestTimeoutMs",
-      DEFAULT_REQUEST_TIMEOUT_MS,
-      100,
-    ),
+    defaultEndpoint,
+    endpoints,
     defaultWorkspaceDir: readString(record, "defaultWorkspaceDir"),
     defaultModel: readString(record, "defaultModel"),
     defaultServiceTier: readString(record, "defaultServiceTier"),

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1493,6 +1493,23 @@ export class CodexPluginController {
     return lines.join("\n");
   }
 
+  private buildEndpointSelectionNotice(
+    endpointId: string,
+    binding?: StoredBinding | null,
+  ): string {
+    return [
+      `Selected endpoint set to ${endpointId}.`,
+      binding && this.getEndpointIdForBinding(binding) !== endpointId
+        ? `This conversation is still bound to a thread on ${this.getEndpointIdForBinding(binding)}. Use /cas_resume to browse/bind on ${endpointId}.`
+        : "",
+      "",
+      this.formatEndpointListText({
+        selectedEndpointId: endpointId,
+        binding,
+      }),
+    ].filter(Boolean).join("\n");
+  }
+
   private getClientForEndpoint(endpointId?: string): CodexAppServerModeClient {
     const resolvedEndpointId =
       endpointId && this.settings.endpoints.some((entry) => entry.id === endpointId)
@@ -6250,6 +6267,7 @@ export class CodexPluginController {
       };
       await this.setSelectedEndpointId(conversation, callback.endpointId);
       const refreshedBinding = this.store.getBinding(callback.conversation);
+      const text = this.buildEndpointSelectionNotice(callback.endpointId, refreshedBinding);
       if (callback.returnToStatus && refreshedBinding) {
         const statusCard = await this.buildStatusCard(
           conversation,
@@ -6261,23 +6279,14 @@ export class CodexPluginController {
             text: statusCard.text,
             buttons: statusCard.buttons,
           });
+          await this.sendText(conversation, text);
         } else {
           await responders.acknowledge?.();
           await this.sendText(conversation, statusCard.text, { buttons: statusCard.buttons });
+          await this.sendText(conversation, text);
         }
         return;
       }
-      const text = [
-        `Selected endpoint set to ${callback.endpointId}.`,
-        refreshedBinding && this.getEndpointIdForBinding(refreshedBinding) !== callback.endpointId
-          ? `This conversation is still bound to a thread on ${this.getEndpointIdForBinding(refreshedBinding)}. Use /cas_resume to browse/bind on ${callback.endpointId}.`
-          : "",
-        "",
-        this.formatEndpointListText({
-          selectedEndpointId: callback.endpointId,
-          binding: refreshedBinding,
-        }),
-      ].filter(Boolean).join("\n");
       if (responders.sourceMessage) {
         const picker = await this.buildEndpointPicker(conversation, refreshedBinding, {
           returnToStatus: false,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2640,9 +2640,13 @@ export class CodexPluginController {
     const currentReasoning = normalizeReasoningEffort(
       effectiveState?.reasoningEffort ?? binding.preferences?.preferredReasoningEffort,
     );
-    const [showModelPicker, showReasoningPicker, togglePermissions, compactThread, stopRun, refreshStatus, detachThread, showSkills, showMcp] = await Promise.all([
+    const [showModelPicker, showEndpointPicker, showReasoningPicker, togglePermissions, compactThread, stopRun, refreshStatus, detachThread, showSkills, showMcp] = await Promise.all([
       this.store.putCallback({
         kind: "show-model-picker",
+        conversation,
+      }),
+      this.store.putCallback({
+        kind: "show-endpoint-picker",
         conversation,
       }),
       this.store.putCallback({
@@ -2682,6 +2686,10 @@ export class CodexPluginController {
       {
         text: "Select Model",
         callback_data: `${INTERACTIVE_NAMESPACE}:${showModelPicker.token}`,
+      },
+      {
+        text: "Endpoint",
+        callback_data: `${INTERACTIVE_NAMESPACE}:${showEndpointPicker.token}`,
       },
     ];
     if (currentModel) {
@@ -2870,6 +2878,58 @@ export class CodexPluginController {
     }
     return {
       text: formatModels(models, effectiveState),
+      buttons,
+    };
+  }
+
+  private async buildEndpointPicker(
+    conversation: ConversationTarget,
+    binding: StoredBinding | null,
+    opts?: {
+      returnToStatus?: boolean;
+      statusMessage?: InteractiveMessageRef;
+    },
+  ): Promise<PickerRender> {
+    const selectedEndpointId = this.getSelectedEndpointId(conversation, binding);
+    const buttons: PluginInteractiveButtons = [];
+    for (const endpoint of this.settings.endpoints) {
+      const endpointId = endpoint.id ?? this.settings.defaultEndpoint;
+      const callback = await this.store.putCallback({
+        kind: "set-endpoint",
+        conversation,
+        endpointId,
+        returnToStatus: opts?.returnToStatus,
+        statusMessage: opts?.statusMessage,
+      });
+      const flags = [
+        endpointId === selectedEndpointId ? "selected" : "",
+        binding && endpointId === this.getEndpointIdForBinding(binding) ? "bound" : "",
+        endpointId === this.settings.defaultEndpoint ? "default" : "",
+      ].filter(Boolean);
+      buttons.push([
+        {
+          text: `${endpointId}${flags.length ? ` (${flags.join(", ")})` : ""}`,
+          callback_data: `${INTERACTIVE_NAMESPACE}:${callback.token}`,
+        },
+      ]);
+    }
+    if (opts?.returnToStatus) {
+      const cancel = await this.store.putCallback({
+        kind: "refresh-status",
+        conversation,
+      });
+      buttons.push([
+        {
+          text: "Cancel",
+          callback_data: `${INTERACTIVE_NAMESPACE}:${cancel.token}`,
+        },
+      ]);
+    }
+    return {
+      text: this.formatEndpointListText({
+        selectedEndpointId,
+        binding,
+      }),
       buttons,
     };
   }
@@ -3477,12 +3537,8 @@ export class CodexPluginController {
     }
     const currentSelected = this.getSelectedEndpointId(conversation, binding);
     if (!parsed.endpointId) {
-      return {
-        text: this.formatEndpointListText({
-          selectedEndpointId: currentSelected,
-          binding,
-        }),
-      };
+      const picker = await this.buildEndpointPicker(conversation, binding);
+      return buildReplyWithButtons(picker.text, picker.buttons);
     }
     const requested = parsed.endpointId.trim();
     const endpoint = this.settings.endpoints.find((entry) => entry.id === requested);
@@ -6099,6 +6155,48 @@ export class CodexPluginController {
       );
       return;
     }
+    if (callback.kind === "show-endpoint-picker") {
+      const binding = this.store.getBinding(callback.conversation);
+      await this.store.removeCallback(callback.token);
+      const conversation = {
+        ...callback.conversation,
+        threadId: responders.conversation.threadId,
+      };
+      if (responders.sourceMessage) {
+        const [picker, statusCard] = await Promise.all([
+          this.buildEndpointPicker(
+            conversation,
+            binding,
+            {
+              returnToStatus: true,
+            },
+          ),
+          binding
+            ? this.buildStatusCard(
+                conversation,
+                binding,
+                true,
+              )
+            : Promise.resolve({ text: this.formatEndpointListText({ selectedEndpointId: this.getSelectedEndpointId(conversation, binding), binding }), buttons: undefined }),
+        ]);
+        await responders.editPicker({
+          text: statusCard.text,
+          buttons: picker.buttons,
+        });
+        return;
+      }
+      const picker = await this.buildEndpointPicker(
+        conversation,
+        binding,
+        {
+          returnToStatus: Boolean(binding),
+          statusMessage: responders.sourceMessage,
+        },
+      );
+      await responders.acknowledge?.();
+      await this.sendPickerToConversation(conversation, picker);
+      return;
+    }
     if (callback.kind === "show-model-picker") {
       const binding = this.store.getBinding(callback.conversation);
       await this.store.removeCallback(callback.token);
@@ -6141,6 +6239,60 @@ export class CodexPluginController {
       );
       await responders.acknowledge?.();
       await this.sendPickerToConversation(conversation, picker);
+      return;
+    }
+    if (callback.kind === "set-endpoint") {
+      const binding = this.store.getBinding(callback.conversation);
+      await this.store.removeCallback(callback.token);
+      const conversation = {
+        ...callback.conversation,
+        threadId: responders.conversation.threadId,
+      };
+      await this.setSelectedEndpointId(conversation, callback.endpointId);
+      const refreshedBinding = this.store.getBinding(callback.conversation);
+      if (callback.returnToStatus && refreshedBinding) {
+        const statusCard = await this.buildStatusCard(
+          conversation,
+          refreshedBinding,
+          true,
+        );
+        if (responders.sourceMessage) {
+          await responders.editPicker({
+            text: statusCard.text,
+            buttons: statusCard.buttons,
+          });
+        } else {
+          await responders.acknowledge?.();
+          await this.sendText(conversation, statusCard.text, { buttons: statusCard.buttons });
+        }
+        return;
+      }
+      const text = [
+        `Selected endpoint set to ${callback.endpointId}.`,
+        refreshedBinding && this.getEndpointIdForBinding(refreshedBinding) !== callback.endpointId
+          ? `This conversation is still bound to a thread on ${this.getEndpointIdForBinding(refreshedBinding)}. Use /cas_resume to browse/bind on ${callback.endpointId}.`
+          : "",
+        "",
+        this.formatEndpointListText({
+          selectedEndpointId: callback.endpointId,
+          binding: refreshedBinding,
+        }),
+      ].filter(Boolean).join("\n");
+      if (responders.sourceMessage) {
+        const picker = await this.buildEndpointPicker(conversation, refreshedBinding, {
+          returnToStatus: false,
+        });
+        await responders.editPicker({
+          text,
+          buttons: picker.buttons,
+        });
+      } else {
+        await responders.acknowledge?.();
+        const picker = await this.buildEndpointPicker(conversation, refreshedBinding, {
+          returnToStatus: false,
+        });
+        await this.sendText(conversation, text, { buttons: picker.buttons });
+      }
       return;
     }
     if (callback.kind === "set-model") {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1210,6 +1210,21 @@ function hasCommandPreferenceOverrides(overrides: CommandPreferenceOverrides): b
   );
 }
 
+function parseEndpointArgs(args: string): { endpointId?: string; error?: string } {
+  const trimmed = args.trim();
+  if (!trimmed) {
+    return {};
+  }
+  const tokens = normalizeOptionDashes(trimmed)
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.length !== 1) {
+    return { error: formatCommandUsage("cas_endpoint") };
+  }
+  return { endpointId: tokens[0] };
+}
+
 function mergeConversationPreferences(
   existing: ConversationPreferences | undefined,
   updates: Partial<ConversationPreferences>,
@@ -1360,7 +1375,7 @@ function summarizeTextForLog(text: string, maxChars = 120): string {
 
 export class CodexPluginController {
   private readonly settings;
-  private readonly client;
+  private readonly clients = new Map<string, CodexAppServerModeClient>();
   private readonly activeRuns = new Map<string, ActiveRunRecord>();
   private readonly threadChangesCache = new Map<string, Promise<boolean | undefined>>();
   private readonly store;
@@ -1370,7 +1385,6 @@ export class CodexPluginController {
 
   constructor(private readonly api: OpenClawPluginApi) {
     this.settings = resolvePluginSettings(this.api.pluginConfig);
-    this.client = new CodexAppServerModeClient(this.settings, this.api.logger);
     this.store = new PluginStateStore(this.api.runtime.state.resolveStateDir());
   }
 
@@ -1392,7 +1406,9 @@ export class CodexPluginController {
       return;
     }
     await this.store.load();
-    await this.client.logStartupProbe().catch(() => undefined);
+    for (const endpoint of this.settings.endpoints) {
+      await this.getClientForEndpoint(endpoint.id).logStartupProbe().catch(() => undefined);
+    }
     this.started = true;
   }
 
@@ -1404,8 +1420,105 @@ export class CodexPluginController {
       await active.handle.interrupt().catch(() => undefined);
     }
     this.activeRuns.clear();
-    await this.client.close().catch(() => undefined);
+    for (const client of this.clients.values()) {
+      await client.close().catch(() => undefined);
+    }
+    this.clients.clear();
     this.started = false;
+  }
+
+  private getEndpointIdForBinding(binding: StoredBinding | StoredPendingBind | null | undefined): string {
+    const requested = binding?.endpointId?.trim();
+    if (requested && this.settings.endpoints.some((entry) => entry.id === requested)) {
+      return requested;
+    }
+    return this.settings.defaultEndpoint;
+  }
+
+  private getSelectedEndpointId(
+    conversation: ConversationTarget | null | undefined,
+    binding?: StoredBinding | StoredPendingBind | null,
+  ): string {
+    if (conversation) {
+      const stored = this.store.getConversationEndpoint(conversation)?.endpointId?.trim();
+      if (stored && this.settings.endpoints.some((entry) => entry.id === stored)) {
+        return stored;
+      }
+    }
+    return this.getEndpointIdForBinding(binding);
+  }
+
+  private async setSelectedEndpointId(conversation: ConversationTarget, endpointId: string): Promise<void> {
+    await this.store.upsertConversationEndpoint({
+      conversation: {
+        channel: conversation.channel,
+        accountId: conversation.accountId,
+        conversationId: conversation.conversationId,
+        parentConversationId: conversation.parentConversationId,
+      },
+      endpointId,
+      updatedAt: Date.now(),
+    });
+  }
+
+  private formatEndpointListText(params: {
+    selectedEndpointId: string;
+    binding?: StoredBinding | null;
+  }): string {
+    const lines = [
+      `Selected endpoint: ${params.selectedEndpointId}`,
+      params.binding
+        ? `Bound endpoint: ${this.getEndpointIdForBinding(params.binding)}`
+        : "Bound endpoint: none",
+      "",
+      "Configured endpoints:",
+      ...this.settings.endpoints.map((endpoint) => {
+        const markers = [
+          endpoint.id === params.selectedEndpointId ? "selected" : "",
+          params.binding && endpoint.id === this.getEndpointIdForBinding(params.binding) ? "bound" : "",
+          endpoint.id === this.settings.defaultEndpoint ? "default" : "",
+        ].filter(Boolean);
+        return `- ${endpoint.id} (${endpoint.transport})${markers.length ? ` [${markers.join(", ")}]` : ""}`;
+      }),
+    ];
+    if (
+      params.binding &&
+      this.getEndpointIdForBinding(params.binding) !== params.selectedEndpointId
+    ) {
+      lines.push(
+        "",
+        "Note: this conversation is still bound to a thread on a different endpoint. Use /cas_resume after detaching if you want to bind on the selected endpoint.",
+      );
+    }
+    return lines.join("\n");
+  }
+
+  private getClientForEndpoint(endpointId?: string): CodexAppServerModeClient {
+    const resolvedEndpointId =
+      endpointId && this.settings.endpoints.some((entry) => entry.id === endpointId)
+        ? endpointId
+        : this.settings.defaultEndpoint;
+    const existing = this.clients.get(resolvedEndpointId);
+    if (existing) {
+      return existing;
+    }
+    const endpoint =
+      this.settings.endpoints.find((entry) => entry.id === resolvedEndpointId) ??
+      this.settings.endpoints[0];
+    if (!endpoint) {
+      throw new Error("Codex endpoint configuration is missing.");
+    }
+    const client = new CodexAppServerModeClient(endpoint, this.api.logger);
+    this.clients.set(resolvedEndpointId, client);
+    return client;
+  }
+
+  private getClientForBinding(binding: StoredBinding | StoredPendingBind | null | undefined): CodexAppServerModeClient {
+    return this.getClientForEndpoint(this.getEndpointIdForBinding(binding));
+  }
+
+  private get client(): CodexAppServerModeClient {
+    return this.getClientForEndpoint();
   }
 
   async handleConversationBindingResolved(
@@ -1441,6 +1554,7 @@ export class CodexPluginController {
     }
     await this.bindConversation(conversation, {
       threadId: pending.threadId,
+      endpointId: pending.endpointId,
       workspaceDir: pending.workspaceDir,
       threadTitle: pending.threadTitle,
       permissionsMode: normalizePermissionsMode(pending.permissionsMode),
@@ -1943,6 +2057,8 @@ export class CodexPluginController {
         return await this.handleFastCommand(binding, args);
       case "cas_model":
         return await this.handleModelCommand(conversation, binding, args);
+      case "cas_endpoint":
+        return await this.handleEndpointCommand(conversation, binding, args);
       case "cas_permissions":
         return await this.handlePermissionsCommand(
           conversation,
@@ -1967,6 +2083,7 @@ export class CodexPluginController {
   private async handleStartNewThreadSelection(
     conversation: ConversationTarget | null,
     binding: StoredBinding | null,
+    endpointId: string | undefined,
     parsed: ReturnType<typeof parseThreadSelectionArgs>,
     channel: string,
     requestConversationBinding?: PickerResponders["requestConversationBinding"],
@@ -1975,7 +2092,7 @@ export class CodexPluginController {
       return { text: "This command needs a Telegram or Discord conversation." };
     }
     if (parsed.listProjects || !parsed.query) {
-      const picker = await this.renderProjectPicker(conversation, binding, parsed, 0, "start-new-thread");
+      const picker = await this.renderProjectPicker(conversation, binding, parsed, 0, "start-new-thread", endpointId);
       if (isDiscordChannel(channel) && picker.buttons) {
         try {
           await this.sendDiscordPicker(conversation, picker);
@@ -1990,7 +2107,7 @@ export class CodexPluginController {
 
     const workspaceDir = await this.resolveNewThreadWorkspaceDir(binding, parsed);
     if (!workspaceDir) {
-      const picker = await this.renderProjectPicker(conversation, binding, parsed, 0, "start-new-thread");
+      const picker = await this.renderProjectPicker(conversation, binding, parsed, 0, "start-new-thread", endpointId);
       if (isDiscordChannel(channel) && picker.buttons) {
         try {
           await this.sendDiscordPicker(conversation, picker);
@@ -2008,6 +2125,7 @@ export class CodexPluginController {
     const result = await this.startNewThreadAndBindConversation(
       conversation,
       binding,
+      endpointId,
       workspaceDir,
       parsed.syncTopic,
       {
@@ -2029,6 +2147,7 @@ export class CodexPluginController {
   private async handleListCommand(
     conversation: ConversationTarget | null,
     binding: StoredBinding | null,
+    endpointId: string | undefined,
     filter: string,
     channel: string,
   ): Promise<ReplyPayload> {
@@ -2037,8 +2156,8 @@ export class CodexPluginController {
       return { text: "This command needs a Telegram or Discord conversation." };
     }
     const picker = parsed.listProjects
-      ? await this.renderProjectPicker(conversation, binding, parsed, 0)
-      : await this.renderThreadPicker(conversation, binding, parsed, 0);
+      ? await this.renderProjectPicker(conversation, binding, parsed, 0, "resume-thread", endpointId)
+      : await this.renderThreadPicker(conversation, binding, parsed, 0, undefined, endpointId);
     if (isDiscordChannel(channel) && picker.buttons) {
       try {
         await this.sendDiscordPicker(conversation, picker);
@@ -2068,7 +2187,16 @@ export class CodexPluginController {
     if (parsed.error) {
       return { text: parsed.error };
     }
-    if (parsed.requestedYolo && !this.hasFullAccessProfile()) {
+    const selectedEndpointId = this.getSelectedEndpointId(conversation, binding);
+    const resumeBinding =
+      binding && this.getEndpointIdForBinding(binding) === selectedEndpointId ? binding : null;
+    const resumePendingBind =
+      pendingBind && this.getEndpointIdForBinding(pendingBind) === selectedEndpointId ? pendingBind : null;
+    const resumeHydratedPendingBind =
+      hydratedPendingBind && this.getEndpointIdForBinding(hydratedPendingBind) === selectedEndpointId
+        ? hydratedPendingBind
+        : undefined;
+    if (parsed.requestedYolo && !this.hasFullAccessProfile(selectedEndpointId)) {
       return { text: "Full Access is unavailable in the current Codex Desktop session." };
     }
     if (parsed.requestedFast && parsed.requestedModel && !modelSupportsFast(parsed.requestedModel)) {
@@ -2084,22 +2212,23 @@ export class CodexPluginController {
     if (parsed.startNew) {
       return await this.handleStartNewThreadSelection(
         conversation,
-        binding,
+        resumeBinding,
+        selectedEndpointId,
         parsed,
         channel,
         bindingApi.requestConversationBinding,
       );
     }
     if (
-      hydratedPendingBind?.notifyBound &&
+      resumeHydratedPendingBind?.notifyBound &&
       !parsed.listProjects &&
       !parsed.query
     ) {
-      if (hydratedPendingBind.syncTopic) {
+      if (resumeHydratedPendingBind.syncTopic) {
         const syncedName = buildResumeTopicName({
-          title: hydratedPendingBind.threadTitle,
-          projectKey: hydratedPendingBind.workspaceDir,
-          threadId: hydratedPendingBind.threadId,
+          title: resumeHydratedPendingBind.threadTitle,
+          projectKey: resumeHydratedPendingBind.workspaceDir,
+          threadId: resumeHydratedPendingBind.threadId,
         });
         if (syncedName) {
           await this.renameConversationIfSupported(conversation, syncedName);
@@ -2108,24 +2237,25 @@ export class CodexPluginController {
       await this.sendBoundConversationNotifications(conversation);
       return {};
     }
-    if (pendingBind && !binding && !parsed.listProjects && !parsed.query) {
-      const syncTopic = parsed.syncTopic || Boolean(pendingBind.syncTopic);
+    if (resumePendingBind && !resumeBinding && !parsed.listProjects && !parsed.query) {
+      const syncTopic = parsed.syncTopic || Boolean(resumePendingBind.syncTopic);
       const targetPermissionsMode = this.resolveRequestedPermissionsMode(
-        normalizePermissionsMode(pendingBind.permissionsMode),
+        normalizePermissionsMode(resumePendingBind.permissionsMode),
         parsed.requestedYolo,
       );
       const preferences = this.buildBindingPreferencesWithOverrides(
-        pendingBind.preferences,
+        resumePendingBind.preferences,
         overrides,
         parsed.requestedModel,
       );
       const bindResult = await this.requestConversationBinding(
         conversation,
         {
-          threadId: pendingBind.threadId,
-          workspaceDir: pendingBind.workspaceDir,
+          threadId: resumePendingBind.threadId,
+          endpointId: resumePendingBind.endpointId,
+          workspaceDir: resumePendingBind.workspaceDir,
           permissionsMode: targetPermissionsMode,
-          threadTitle: pendingBind.threadTitle,
+          threadTitle: resumePendingBind.threadTitle,
           syncTopic,
           preferences,
           notifyBound: true,
@@ -2140,9 +2270,9 @@ export class CodexPluginController {
       }
       if (syncTopic) {
         const syncedName = buildResumeTopicName({
-          title: pendingBind.threadTitle,
-          projectKey: pendingBind.workspaceDir,
-          threadId: pendingBind.threadId,
+          title: resumePendingBind.threadTitle,
+          projectKey: resumePendingBind.workspaceDir,
+          threadId: resumePendingBind.threadId,
         });
         if (syncedName) {
           await this.renameConversationIfSupported(conversation, syncedName);
@@ -2153,11 +2283,18 @@ export class CodexPluginController {
     }
     if (parsed.listProjects || !parsed.query) {
       const passthroughArgs = formatThreadSelectionFlags(parsed);
-      return await this.handleListCommand(conversation, binding, passthroughArgs, channel);
+      return await this.handleListCommand(
+        conversation,
+        resumeBinding,
+        selectedEndpointId,
+        passthroughArgs,
+        channel,
+      );
     }
-    const workspaceDir = this.resolveThreadWorkspaceDir(parsed, binding, false);
+    const workspaceDir = this.resolveThreadWorkspaceDir(parsed, resumeBinding, false);
     const selection = await this.resolveSingleThread(
-      binding?.sessionKey,
+      selectedEndpointId,
+      resumeBinding?.sessionKey,
       workspaceDir,
       parsed.query,
     );
@@ -2165,7 +2302,14 @@ export class CodexPluginController {
       return { text: `No Codex thread matched "${parsed.query}".` };
     }
     if (selection.kind === "ambiguous") {
-      const picker = await this.renderThreadPicker(conversation, binding, parsed, 0);
+      const picker = await this.renderThreadPicker(
+        conversation,
+        resumeBinding,
+        parsed,
+        0,
+        undefined,
+        selectedEndpointId,
+      );
       if (isDiscordChannel(channel) && picker.buttons) {
         try {
           await this.sendDiscordPicker(conversation, picker);
@@ -2180,21 +2324,22 @@ export class CodexPluginController {
       return buildReplyWithButtons(picker.text, picker.buttons);
     }
     const targetPermissionsMode = this.resolveRequestedPermissionsMode(
-      this.getPermissionsMode(binding),
+      this.getPermissionsMode(resumeBinding),
       parsed.requestedYolo,
     );
     const preferences = this.buildBindingPreferencesWithOverrides(
-      binding?.preferences,
+      resumeBinding?.preferences,
       overrides,
       parsed.requestedModel,
     );
     const bindResult = await this.requestConversationBinding(conversation, {
       threadId: selection.thread.threadId,
+      endpointId: selectedEndpointId,
       workspaceDir:
         selection.thread.projectKey ||
         workspaceDir ||
         resolveWorkspaceDir({
-          bindingWorkspaceDir: binding?.workspaceDir,
+          bindingWorkspaceDir: resumeBinding?.workspaceDir,
           configuredWorkspaceDir: this.settings.defaultWorkspaceDir,
           serviceWorkspaceDir: this.serviceWorkspaceDir,
       }),
@@ -2258,7 +2403,7 @@ export class CodexPluginController {
         currentPermissionsMode,
         parsed.requestedYolo,
       );
-      if (targetPermissionsMode === "full-access" && !this.hasFullAccessProfile()) {
+      if (targetPermissionsMode === "full-access" && !this.hasFullAccessProfile(binding)) {
         note = buildPermissionsUnavailableNote();
         const card = await this.buildStatusCard(conversation, binding, bindingActive);
         const text = `${card.text}\n\n${note}`;
@@ -2308,8 +2453,13 @@ export class CodexPluginController {
     return await this.sendStatusCardCommandReply(conversation, text, card.buttons);
   }
 
-  private hasFullAccessProfile(): boolean {
-    return this.client.hasProfile("full-access");
+  private hasFullAccessProfile(
+    bindingOrEndpoint?: StoredBinding | StoredPendingBind | string | null,
+  ): boolean {
+    if (typeof bindingOrEndpoint === "string") {
+      return this.getClientForEndpoint(bindingOrEndpoint).hasProfile("full-access");
+    }
+    return this.getClientForBinding(bindingOrEndpoint).hasProfile("full-access");
   }
 
   private getPermissionsMode(binding: StoredBinding | null | undefined): PermissionsMode {
@@ -2336,7 +2486,8 @@ export class CodexPluginController {
     effectiveState: ThreadState | undefined;
   }> {
     const profile = this.getPermissionsMode(binding);
-    const state = await this.client.readThreadState({
+    const client = this.getClientForBinding(binding);
+    const state = await client.readThreadState({
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
@@ -2359,7 +2510,7 @@ export class CodexPluginController {
     }
     const configuredDefault = this.settings.defaultModel?.trim() || undefined;
     try {
-      const models = await this.client.listModels({
+      const models = await this.getClientForBinding(binding).listModels({
         profile: this.getPermissionsMode(binding),
         sessionKey: binding.sessionKey,
       });
@@ -2413,9 +2564,10 @@ export class CodexPluginController {
     },
   ): Promise<ThreadState | undefined> {
     const profile = this.getPermissionsMode(binding);
+    const client = this.getClientForBinding(binding);
     let state =
       opts?.threadState ??
-      (await this.client.readThreadState({
+      (await client.readThreadState({
         profile,
         sessionKey: binding.sessionKey,
         threadId: binding.threadId,
@@ -2423,7 +2575,7 @@ export class CodexPluginController {
     let desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
     if (desired.model && desired.model !== state?.model?.trim()) {
       try {
-        state = await this.client.setThreadModel({
+        state = await client.setThreadModel({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -2440,7 +2592,7 @@ export class CodexPluginController {
     const desiredServiceTier = normalizePreferenceServiceTier(desired.effectiveState?.serviceTier);
     if (desiredServiceTier !== currentServiceTier) {
       try {
-        state = await this.client.setThreadServiceTier({
+        state = await client.setThreadServiceTier({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -2463,7 +2615,7 @@ export class CodexPluginController {
       )
     ) {
       try {
-        state = await this.client.setThreadPermissions({
+        state = await client.setThreadPermissions({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -2674,8 +2826,9 @@ export class CodexPluginController {
     },
   ): Promise<PickerRender> {
     const profile = this.getPermissionsMode(binding);
+    const client = this.getClientForBinding(binding);
     const [models, threadState] = await Promise.all([
-      this.client.listModels({ profile, sessionKey: binding.sessionKey }),
+      client.listModels({ profile, sessionKey: binding.sessionKey }),
       this.readEffectiveThreadState(binding),
     ]);
     const { state, effectiveState } = threadState;
@@ -2822,7 +2975,7 @@ export class CodexPluginController {
       configuredWorkspaceDir: this.settings.defaultWorkspaceDir,
       serviceWorkspaceDir: this.serviceWorkspaceDir,
     });
-    const skills = dedupeSkillsByName(await this.client.listSkills({
+    const skills = dedupeSkillsByName(await this.getClientForBinding(binding).listSkills({
       profile: this.getPermissionsMode(binding),
       sessionKey: binding?.sessionKey,
       workspaceDir,
@@ -3077,7 +3230,7 @@ export class CodexPluginController {
           void this.sendText(conversation, "Codex is still compacting.");
         }, COMPACT_PROGRESS_INTERVAL_MS);
       }, COMPACT_PROGRESS_DELAY_MS);
-      const result = await this.client.compactThread({
+      const result = await this.getClientForBinding(binding).compactThread({
         profile,
         sessionKey: binding.sessionKey,
         threadId: binding.threadId,
@@ -3133,7 +3286,7 @@ export class CodexPluginController {
       configuredWorkspaceDir: this.settings.defaultWorkspaceDir,
       serviceWorkspaceDir: this.serviceWorkspaceDir,
     });
-    const skills = dedupeSkillsByName(await this.client.listSkills({
+    const skills = dedupeSkillsByName(await this.getClientForBinding(binding).listSkills({
       profile: this.getPermissionsMode(binding),
       sessionKey: binding?.sessionKey,
       workspaceDir,
@@ -3168,7 +3321,7 @@ export class CodexPluginController {
   }
 
   private async handleExperimentalCommand(binding: StoredBinding | null): Promise<ReplyPayload> {
-    const features = await this.client.listExperimentalFeatures({
+    const features = await this.getClientForBinding(binding).listExperimentalFeatures({
       profile: this.getPermissionsMode(binding),
       sessionKey: binding?.sessionKey,
     });
@@ -3176,7 +3329,7 @@ export class CodexPluginController {
   }
 
   private async handleMcpCommand(binding: StoredBinding | null, args: string): Promise<ReplyPayload> {
-    const servers = await this.client.listMcpServers({
+    const servers = await this.getClientForBinding(binding).listMcpServers({
       profile: this.getPermissionsMode(binding),
       sessionKey: binding?.sessionKey,
     });
@@ -3213,7 +3366,7 @@ export class CodexPluginController {
       action === "toggle" ? (currentTier === "fast" ? null : "fast")
       : action === "on" ? "fast"
       : null;
-    const updatedState = await this.client.setThreadServiceTier({
+    const updatedState = await this.getClientForBinding(binding).setThreadServiceTier({
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
@@ -3245,13 +3398,15 @@ export class CodexPluginController {
     const trimmedArgs = args.trim();
     const profile = this.getPermissionsMode(binding);
     if (!binding) {
-      const models = await this.client.listModels({ profile });
+      const models = await this.getClientForEndpoint(
+        this.getSelectedEndpointId(conversation, binding),
+      ).listModels({ profile });
       return { text: formatModels(models) };
     }
     if (!trimmedArgs) {
       if (!conversation) {
         const [models, { effectiveState }] = await Promise.all([
-          this.client.listModels({ profile, sessionKey: binding.sessionKey }),
+          this.getClientForBinding(binding).listModels({ profile, sessionKey: binding.sessionKey }),
           this.readEffectiveThreadState(binding),
         ]);
         return { text: formatModels(models, effectiveState) };
@@ -3271,7 +3426,7 @@ export class CodexPluginController {
       }
       return buildReplyWithButtons(picker.text, picker.buttons);
     }
-    const state = await this.client.setThreadModel({
+    const state = await this.getClientForBinding(binding).setThreadModel({
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
@@ -3282,7 +3437,7 @@ export class CodexPluginController {
       : "default";
     const nextState =
       !modelSupportsFast(trimmedArgs) && normalizeServiceTier(state.serviceTier) === "fast"
-        ? await this.client
+        ? await this.getClientForBinding(binding)
             .setThreadServiceTier({
               profile,
               sessionKey: binding.sessionKey,
@@ -3306,6 +3461,55 @@ export class CodexPluginController {
     };
     await this.store.upsertBinding(updatedBinding);
     return { text: `Codex model set to ${nextState.model || trimmedArgs}.` };
+  }
+
+  private async handleEndpointCommand(
+    conversation: ConversationTarget | null,
+    binding: StoredBinding | null,
+    args: string,
+  ): Promise<ReplyPayload> {
+    if (!conversation) {
+      return { text: "This command needs a Telegram or Discord conversation." };
+    }
+    const parsed = parseEndpointArgs(args);
+    if (parsed.error) {
+      return { text: parsed.error };
+    }
+    const currentSelected = this.getSelectedEndpointId(conversation, binding);
+    if (!parsed.endpointId) {
+      return {
+        text: this.formatEndpointListText({
+          selectedEndpointId: currentSelected,
+          binding,
+        }),
+      };
+    }
+    const requested = parsed.endpointId.trim();
+    const endpoint = this.settings.endpoints.find((entry) => entry.id === requested);
+    if (!endpoint) {
+      return {
+        text: [
+          `Unknown endpoint: ${requested}`,
+          "",
+          this.formatEndpointListText({
+            selectedEndpointId: currentSelected,
+            binding,
+          }),
+        ].join("\n"),
+      };
+    }
+    await this.setSelectedEndpointId(conversation, endpoint.id || requested);
+    const nextSelected = endpoint.id || requested;
+    const lines = [
+      `Selected endpoint set to ${nextSelected}.`,
+    ];
+    if (binding && this.getEndpointIdForBinding(binding) !== nextSelected) {
+      lines.push(
+        `This conversation is still bound to a thread on ${this.getEndpointIdForBinding(binding)}. Use /cas_resume to browse/bind on ${nextSelected}.`,
+      );
+    }
+    lines.push("", this.formatEndpointListText({ selectedEndpointId: nextSelected, binding }));
+    return { text: lines.join("\n") };
   }
 
   private async handlePermissionsCommand(
@@ -3354,7 +3558,7 @@ export class CodexPluginController {
       const picker = await this.buildRenameStylePicker(conversation, binding, Boolean(parsed?.syncTopic));
       return buildReplyWithButtons(picker.text, picker.buttons);
     }
-    await this.client.setThreadName({
+    await this.getClientForBinding(binding).setThreadName({
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
@@ -3462,7 +3666,7 @@ export class CodexPluginController {
     if (!name) {
       throw new Error("Unable to derive a Codex thread name.");
     }
-    await this.client.setThreadName({
+    await this.getClientForBinding(binding).setThreadName({
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
@@ -3537,7 +3741,7 @@ export class CodexPluginController {
       params.binding,
       this.settings.defaultModel,
     );
-    const run = this.client.startTurn({
+    const run = this.getClientForBinding(params.binding).startTurn({
       profile,
       sessionKey: params.binding?.sessionKey,
       workspaceDir: params.workspaceDir,
@@ -3581,7 +3785,7 @@ export class CodexPluginController {
       .then(async (result) => {
         const threadId = result.threadId || run.getThreadId();
         if (threadId) {
-          const state = await this.client
+          const state = await this.getClientForBinding(params.binding)
             .readThreadState({
               profile,
               sessionKey: params.binding?.sessionKey,
@@ -3590,6 +3794,7 @@ export class CodexPluginController {
             .catch(() => null);
           const nextBinding = await this.bindConversation(params.conversation, {
             threadId,
+            endpointId: this.getEndpointIdForBinding(params.binding),
             workspaceDir: state?.cwd || params.workspaceDir,
             threadTitle: state?.threadName,
             permissionsMode: profile,
@@ -3789,7 +3994,7 @@ export class CodexPluginController {
       this.settings.defaultModel,
     );
     const effectiveThreadState = desired.effectiveState;
-    const run = this.client.startTurn({
+    const run = this.getClientForBinding(params.binding).startTurn({
       profile,
       sessionKey: params.binding?.sessionKey,
       workspaceDir: params.workspaceDir,
@@ -3833,7 +4038,7 @@ export class CodexPluginController {
       .then(async (result) => {
         const threadId = result.threadId || run.getThreadId();
         if (threadId) {
-          const state = await this.client
+          const state = await this.getClientForBinding(params.binding)
             .readThreadState({
               profile,
               sessionKey: params.binding?.sessionKey,
@@ -3842,6 +4047,7 @@ export class CodexPluginController {
             .catch(() => null);
           const nextBinding = await this.bindConversation(params.conversation, {
             threadId,
+            endpointId: this.getEndpointIdForBinding(params.binding),
             workspaceDir: state?.cwd || params.workspaceDir,
             threadTitle: state?.threadName,
             permissionsMode: profile,
@@ -3965,7 +4171,7 @@ export class CodexPluginController {
       clearTimeout(progressTimer);
       progressTimer = null;
     };
-    const threadState = await this.client
+    const threadState = await this.getClientForBinding(params.binding)
       .readThreadState({
         profile,
         sessionKey: params.binding.sessionKey,
@@ -3977,7 +4183,7 @@ export class CodexPluginController {
       params.binding,
       this.settings.defaultModel,
     );
-    const run = this.client.startReview({
+    const run = this.getClientForBinding(params.binding).startReview({
       profile,
       sessionKey: params.binding.sessionKey,
       workspaceDir: params.workspaceDir,
@@ -4104,10 +4310,12 @@ export class CodexPluginController {
     }
     if (state.questionnaire) {
       const existing = this.store.getPendingRequestById(state.requestId);
+      const binding = this.store.getBinding(conversation);
       await this.store.upsertPendingRequest({
         requestId: state.requestId,
         conversation,
-        threadId: run.getThreadId() ?? this.store.getBinding(conversation)?.threadId ?? "",
+        threadId: run.getThreadId() ?? binding?.threadId ?? "",
+        endpointId: this.getEndpointIdForBinding(binding),
         workspaceDir,
         state,
         createdAt: existing?.createdAt ?? Date.now(),
@@ -4129,10 +4337,12 @@ export class CodexPluginController {
     );
     const buttons = this.buildPendingButtons(state, callbacks);
     const existing = this.store.getPendingRequestById(state.requestId);
+    const binding = this.store.getBinding(conversation);
     await this.store.upsertPendingRequest({
       requestId: state.requestId,
       conversation,
-      threadId: run.getThreadId() ?? this.store.getBinding(conversation)?.threadId ?? "",
+      threadId: run.getThreadId() ?? binding?.threadId ?? "",
+      endpointId: this.getEndpointIdForBinding(binding),
       workspaceDir,
       state,
       createdAt: existing?.createdAt ?? Date.now(),
@@ -4392,6 +4602,7 @@ export class CodexPluginController {
       parsed: ReturnType<typeof parseThreadSelectionArgs>;
       projectName?: string;
       filterProjectsOnly?: boolean;
+      endpointId?: string;
     },
   ) {
     const workspaceDir = this.resolveThreadWorkspaceDir(
@@ -4400,7 +4611,7 @@ export class CodexPluginController {
       params.filterProjectsOnly || Boolean(params.projectName),
     );
     const profile = this.getPermissionsMode(binding);
-    const threads = await this.client.listThreads({
+    const threads = await this.getClientForEndpoint(params.endpointId ?? this.getEndpointIdForBinding(binding)).listThreads({
       profile,
       sessionKey: binding?.sessionKey,
       workspaceDir,
@@ -4471,6 +4682,7 @@ export class CodexPluginController {
     parsed: ReturnType<typeof parseThreadSelectionArgs>;
     threads: Array<{ threadId: string; title?: string; projectKey?: string }>;
     showProjectName: boolean;
+    endpointId?: string;
   }): Promise<PluginInteractiveButtons | undefined> {
     if (params.threads.length === 0) {
       return undefined;
@@ -4482,6 +4694,7 @@ export class CodexPluginController {
       const callback = await this.store.putCallback({
         kind: "resume-thread",
         conversation: params.conversation,
+        endpointId: params.endpointId,
         threadId: thread.threadId,
         threadTitle: getThreadDisplayTitle(thread),
         workspaceDir: thread.projectKey?.trim() || this.settings.defaultWorkspaceDir || process.cwd(),
@@ -4512,6 +4725,7 @@ export class CodexPluginController {
     projectName?: string;
     page: number;
     totalPages: number;
+    endpointId?: string;
   }): Promise<PluginInteractiveButtons> {
     if (params.totalPages > 1) {
       const navRow: PluginInteractiveButtons[number] = [];
@@ -4523,6 +4737,7 @@ export class CodexPluginController {
             mode: "threads",
             includeAll: params.parsed.includeAll,
             syncTopic: params.parsed.syncTopic,
+            endpointId: params.endpointId,
             workspaceDir: params.parsed.cwd,
             query: params.parsed.query || undefined,
             projectName: params.projectName,
@@ -4545,6 +4760,7 @@ export class CodexPluginController {
             mode: "threads",
             includeAll: params.parsed.includeAll,
             syncTopic: params.parsed.syncTopic,
+            endpointId: params.endpointId,
             workspaceDir: params.parsed.cwd,
             query: params.parsed.query || undefined,
             projectName: params.projectName,
@@ -4572,6 +4788,7 @@ export class CodexPluginController {
         action: "resume-thread",
         includeAll: true,
         syncTopic: params.parsed.syncTopic,
+        endpointId: params.endpointId,
         workspaceDir: params.parsed.cwd,
         requestedModel: params.parsed.requestedModel,
         requestedFast: params.parsed.requestedFast,
@@ -4588,6 +4805,7 @@ export class CodexPluginController {
             action: "start-new-thread",
             includeAll: true,
             syncTopic: params.parsed.syncTopic,
+            endpointId: params.endpointId,
             workspaceDir: params.parsed.cwd,
             query: params.parsed.query || undefined,
             requestedModel: params.parsed.requestedModel,
@@ -4628,15 +4846,17 @@ export class CodexPluginController {
     parsed: ReturnType<typeof parseThreadSelectionArgs>,
     page: number,
     projectName?: string,
+    endpointId?: string,
   ): Promise<PickerRender> {
     const profile = this.getPermissionsMode(binding);
     let { workspaceDir, threads } = await this.listPickerThreads(binding, {
       parsed,
       projectName,
+      endpointId,
     });
     let fallbackToGlobal = false;
     if (threads.length === 0 && workspaceDir != null && !projectName) {
-      const globalResult = await this.client.listThreads({
+      const globalResult = await this.getClientForEndpoint(endpointId ?? this.getEndpointIdForBinding(binding)).listThreads({
         profile,
         sessionKey: binding?.sessionKey,
         workspaceDir: undefined,
@@ -4657,6 +4877,7 @@ export class CodexPluginController {
       parsed,
       threads: pageResult.items,
       showProjectName: !projectName && (fallbackToGlobal || distinctProjects.size > 1),
+      endpointId,
       })) ?? [];
     return {
       text: formatThreadPickerIntro({
@@ -4674,6 +4895,7 @@ export class CodexPluginController {
             buttons: threadButtons,
             parsed,
             projectName,
+            endpointId,
             page: pageResult.page,
             totalPages: pageResult.totalPages,
           }),
@@ -4686,10 +4908,12 @@ export class CodexPluginController {
     parsed: ReturnType<typeof parseThreadSelectionArgs>,
     page: number,
     action: "resume-thread" | "start-new-thread" = "resume-thread",
+    endpointId?: string,
   ): Promise<PickerRender> {
     const { workspaceDir, threads } = await this.listPickerThreads(binding, {
       parsed,
       filterProjectsOnly: true,
+      endpointId,
     });
     const normalizedThreads =
       action === "start-new-thread" ? await this.normalizeNewThreadProjectThreads(threads) : threads;
@@ -4704,6 +4928,7 @@ export class CodexPluginController {
                 return this.store.putCallback({
                   kind: "start-new-thread",
                   conversation,
+                  endpointId,
                   workspaceDir: workspaces[0]?.workspaceDir ?? option.name,
                   syncTopic: parsed.syncTopic,
                   requestedModel: parsed.requestedModel,
@@ -4719,6 +4944,7 @@ export class CodexPluginController {
                   action: "start-new-thread",
                   includeAll: true,
                   syncTopic: parsed.syncTopic,
+                  endpointId,
                   workspaceDir: parsed.cwd,
                   projectName: option.name,
                   requestedModel: parsed.requestedModel,
@@ -4735,6 +4961,7 @@ export class CodexPluginController {
                 mode: "threads",
                 includeAll: true,
                 syncTopic: parsed.syncTopic,
+                endpointId,
                 workspaceDir: parsed.cwd,
                 projectName: option.name,
                 requestedModel: parsed.requestedModel,
@@ -4761,6 +4988,7 @@ export class CodexPluginController {
             action,
             includeAll: true,
             syncTopic: parsed.syncTopic,
+            endpointId,
             workspaceDir: parsed.cwd,
             query: parsed.query || undefined,
             requestedModel: parsed.requestedModel,
@@ -4848,11 +5076,13 @@ export class CodexPluginController {
     parsed: ReturnType<typeof parseThreadSelectionArgs>,
     page: number,
     projectName: string,
+    endpointId?: string,
   ): Promise<PickerRender> {
     const { threads } = await this.listPickerThreads(binding, {
       parsed,
       projectName,
       filterProjectsOnly: true,
+      endpointId,
     });
     const normalizedThreads = await this.normalizeNewThreadProjectThreads(threads);
     const workspaceOptions = paginateItems(listWorkspaceChoices(normalizedThreads, projectName), page);
@@ -4861,6 +5091,7 @@ export class CodexPluginController {
       const callback = await this.store.putCallback({
         kind: "start-new-thread",
         conversation,
+        endpointId,
         workspaceDir: option.workspaceDir,
         syncTopic: parsed.syncTopic,
         requestedModel: parsed.requestedModel,
@@ -4885,6 +5116,7 @@ export class CodexPluginController {
             action: "start-new-thread",
             includeAll: true,
             syncTopic: parsed.syncTopic,
+            endpointId,
             workspaceDir: parsed.cwd,
             projectName,
             requestedModel: parsed.requestedModel,
@@ -4907,6 +5139,7 @@ export class CodexPluginController {
             action: "start-new-thread",
             includeAll: true,
             syncTopic: parsed.syncTopic,
+            endpointId,
             workspaceDir: parsed.cwd,
             projectName,
             requestedModel: parsed.requestedModel,
@@ -4933,6 +5166,7 @@ export class CodexPluginController {
         action: "start-new-thread",
         includeAll: true,
         syncTopic: parsed.syncTopic,
+        endpointId,
         workspaceDir: parsed.cwd,
         requestedModel: parsed.requestedModel,
         requestedFast: parsed.requestedFast,
@@ -4947,6 +5181,7 @@ export class CodexPluginController {
         mode: "threads",
         includeAll: true,
         syncTopic: parsed.syncTopic,
+        endpointId,
         workspaceDir: parsed.cwd,
         requestedModel: parsed.requestedModel,
         requestedFast: parsed.requestedFast,
@@ -5217,6 +5452,7 @@ export class CodexPluginController {
       const result = await this.startNewThreadAndBindConversation(
         callback.conversation,
         this.store.getBinding(callback.conversation),
+        callback.endpointId,
         callback.workspaceDir,
         callback.syncTopic ?? false,
         {
@@ -5241,11 +5477,12 @@ export class CodexPluginController {
         await responders.clear().catch(() => undefined);
       }
       const currentBinding = this.store.getBinding(callback.conversation);
+      const selectedEndpointId = callback.endpointId ?? this.getSelectedEndpointId(callback.conversation, currentBinding);
       const profile = this.resolveRequestedPermissionsMode(
         this.getPermissionsMode(currentBinding),
         callback.requestedYolo,
       );
-      const threadState = await this.client
+      const threadState = await this.getClientForEndpoint(selectedEndpointId)
         .readThreadState({
           profile,
           sessionKey: buildPluginSessionKey(callback.threadId),
@@ -5265,6 +5502,7 @@ export class CodexPluginController {
         callback.conversation,
         {
           threadId: callback.threadId,
+          endpointId: selectedEndpointId,
           workspaceDir: threadState?.cwd?.trim() || callback.workspaceDir,
           permissionsMode: profile,
           threadTitle: threadState?.threadName?.trim() || callback.threadTitle,
@@ -5485,7 +5723,7 @@ export class CodexPluginController {
       const nextTier = currentTier === "fast" ? null : "fast";
       let updatedState = threadState;
       if (threadState) {
-        updatedState = await this.client.setThreadServiceTier({
+        updatedState = await this.getClientForBinding(binding).setThreadServiceTier({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -5615,7 +5853,7 @@ export class CodexPluginController {
       }
       const currentProfile = this.getPermissionsMode(binding);
       const nextProfile = currentProfile === "full-access" ? "default" : "full-access";
-      if (nextProfile === "full-access" && !this.hasFullAccessProfile()) {
+      if (nextProfile === "full-access" && !this.hasFullAccessProfile(binding)) {
         const unchangedBinding: StoredBinding = {
           ...binding,
           updatedAt: Date.now(),
@@ -5916,7 +6154,7 @@ export class CodexPluginController {
       const { state: threadState } = await this.readEffectiveThreadState(binding);
       let state = threadState;
       if (threadState) {
-        state = await this.client.setThreadModel({
+        state = await this.getClientForBinding(binding).setThreadModel({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -5933,7 +6171,7 @@ export class CodexPluginController {
         : "default";
       let nextState = state;
       if (!modelSupportsFast(callback.model) && normalizeServiceTier(state?.serviceTier) === "fast") {
-        nextState = await this.client
+        nextState = await this.getClientForBinding(binding)
           .setThreadServiceTier({
             profile,
             sessionKey: binding.sessionKey,
@@ -6058,6 +6296,7 @@ export class CodexPluginController {
             parsed!,
             callback.view.page,
             callback.view.action ?? "resume-thread",
+            callback.view.endpointId,
           )
         : callback.view.mode === "workspaces"
           ? await this.renderNewThreadWorkspacePicker(
@@ -6066,6 +6305,7 @@ export class CodexPluginController {
               parsed!,
               callback.view.page,
               callback.view.projectName,
+              callback.view.endpointId,
             )
         : callback.view.mode === "skills"
           ? await this.buildSkillsPicker(
@@ -6083,6 +6323,7 @@ export class CodexPluginController {
               parsed!,
               callback.view.page,
               callback.view.projectName,
+              callback.view.endpointId,
             );
     await responders.editPicker(picker);
   }
@@ -6090,6 +6331,7 @@ export class CodexPluginController {
   private async startNewThreadAndBindConversation(
     conversation: ConversationTarget,
     binding: StoredBinding | null,
+    endpointId: string | undefined,
     workspaceDir: string,
     syncTopic: boolean,
     overrides: CommandPreferenceOverrides,
@@ -6103,7 +6345,8 @@ export class CodexPluginController {
       this.getPermissionsMode(binding),
       overrides.requestedYolo,
     );
-    const created = await this.client.startThread({
+    const resolvedEndpointId = endpointId ?? this.getSelectedEndpointId(conversation, binding);
+    const created = await this.getClientForEndpoint(resolvedEndpointId).startThread({
       profile,
       sessionKey: binding?.sessionKey,
       workspaceDir,
@@ -6118,6 +6361,7 @@ export class CodexPluginController {
       conversation,
       {
         threadId: created.threadId,
+        endpointId: resolvedEndpointId,
         workspaceDir: created.cwd?.trim() || workspaceDir,
         threadTitle: created.threadName,
         permissionsMode: profile,
@@ -6148,6 +6392,7 @@ export class CodexPluginController {
   }
 
   private async resolveSingleThread(
+    endpointId: string | undefined,
     sessionKey: string | undefined,
     workspaceDir: string | undefined,
     filter: string,
@@ -6157,7 +6402,7 @@ export class CodexPluginController {
     | { kind: "ambiguous"; threads: Array<{ threadId: string; title?: string; projectKey?: string }> }
   > {
     const trimmed = filter.trim();
-    const threads = await this.client.listThreads({
+    const threads = await this.getClientForEndpoint(endpointId).listThreads({
       profile: "default",
       sessionKey,
       workspaceDir,
@@ -6185,11 +6430,11 @@ export class CodexPluginController {
     binding: StoredBinding,
     profile: PermissionsMode,
   ): Promise<StoredBinding> {
-    if (profile === "full-access" && !this.hasFullAccessProfile()) {
+    if (profile === "full-access" && !this.hasFullAccessProfile(binding)) {
       throw new Error("Full Access is unavailable in the current Codex Desktop session.");
     }
     const preferredPermissions = getPermissionsForMode(profile);
-    const state = await this.client
+    const state = await this.getClientForBinding(binding)
       .setThreadPermissions({
         profile,
         sessionKey: binding.sessionKey,
@@ -6198,7 +6443,7 @@ export class CodexPluginController {
         sandbox: preferredPermissions.sandbox,
       })
       .catch(() =>
-        this.client.readThreadState({
+        this.getClientForBinding(binding).readThreadState({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -6242,6 +6487,7 @@ export class CodexPluginController {
     conversation: ConversationTarget,
     params: {
       threadId: string;
+      endpointId?: string;
       workspaceDir: string;
       threadTitle?: string;
       permissionsMode?: PermissionsMode;
@@ -6260,6 +6506,7 @@ export class CodexPluginController {
       },
       sessionKey,
       threadId: params.threadId,
+      endpointId: params.endpointId ?? existing?.endpointId ?? this.settings.defaultEndpoint,
       workspaceDir: params.workspaceDir,
       permissionsMode: params.permissionsMode ?? existing?.permissionsMode ?? "default",
       pendingPermissionsMode: params.pendingPermissionsMode ?? existing?.pendingPermissionsMode,
@@ -6288,6 +6535,7 @@ export class CodexPluginController {
     }
     const binding = await this.bindConversation(conversation, {
       threadId: pending.threadId,
+      endpointId: pending.endpointId,
       workspaceDir: pending.workspaceDir,
       threadTitle: pending.threadTitle,
       permissionsMode: normalizePermissionsMode(pending.permissionsMode),
@@ -6300,6 +6548,7 @@ export class CodexPluginController {
     conversation: ConversationTarget,
     params: {
       threadId: string;
+      endpointId?: string;
       workspaceDir: string;
       permissionsMode?: PermissionsMode;
       threadTitle?: string;
@@ -6344,6 +6593,7 @@ export class CodexPluginController {
           parentConversationId: conversation.parentConversationId,
         },
           threadId: params.threadId,
+          endpointId: params.endpointId ?? this.settings.defaultEndpoint,
           workspaceDir: params.workspaceDir,
           permissionsMode: params.permissionsMode,
           threadTitle: params.threadTitle,
@@ -6415,7 +6665,7 @@ export class CodexPluginController {
 
     const readStateForRestore = async (): Promise<ThreadState | undefined> => {
       try {
-        return await this.client.readThreadState({
+        return await this.getClientForBinding(binding).readThreadState({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -6436,7 +6686,7 @@ export class CodexPluginController {
       lastAssistantMessage?: string;
     }> => {
       try {
-        return await this.client.readThreadContext({
+        return await this.getClientForBinding(binding).readThreadContext({
           profile,
           sessionKey: binding.sessionKey,
           threadId: binding.threadId,
@@ -6573,6 +6823,7 @@ export class CodexPluginController {
     binding: StoredBinding | null,
     bindingActive: boolean,
   ): Promise<string> {
+    const selectedEndpointId = this.getSelectedEndpointId(conversation, binding);
     const activeRun =
       bindingActive && conversation
         ? this.activeRuns.get(buildConversationKey(conversation))
@@ -6585,18 +6836,19 @@ export class CodexPluginController {
       serviceWorkspaceDir: this.serviceWorkspaceDir,
     });
     const [threadState, account, limits, projectFolder] = await Promise.all([
+      
       binding
-        ? this.client.readThreadState({
+        ? this.getClientForBinding(binding).readThreadState({
             profile,
             sessionKey: binding.sessionKey,
             threadId: binding.threadId,
           }).catch(() => undefined)
         : Promise.resolve(undefined),
-      this.client.readAccount({
+      this.getClientForEndpoint(selectedEndpointId).readAccount({
         profile,
         sessionKey: binding?.sessionKey,
       }).catch(() => null),
-      this.client.readRateLimits({
+      this.getClientForEndpoint(selectedEndpointId).readRateLimits({
         profile,
         sessionKey: binding?.sessionKey,
       }).catch(() => []),
@@ -6616,12 +6868,17 @@ export class CodexPluginController {
       binding && !threadState
         ? "Live thread details are unavailable until Codex materializes the thread, usually after the first user message. Model, reasoning, and fast-mode changes made here are saved as defaults until then."
         : undefined;
+    const endpointNote =
+      binding && this.getEndpointIdForBinding(binding) !== selectedEndpointId
+        ? `Selected endpoint ${selectedEndpointId} differs from the bound endpoint ${this.getEndpointIdForBinding(binding)}.`
+        : undefined;
     this.api.logger.debug?.(
       `codex status snapshot bindingActive=${bindingActive ? "yes" : "no"} activeRun=${activeRun?.mode ?? "none"} boundThread=${binding?.threadId ?? "<none>"} raw=${formatThreadStateForLog(threadState)} effective=${formatThreadStateForLog(displayThreadState)} ${formatBindingPreferencesForLog(binding)} threadCwd=${displayThreadState?.cwd?.trim() || "<none>"}`,
     );
 
     return formatCodexStatusText({
       pluginVersion: PLUGIN_VERSION,
+      endpointId: selectedEndpointId,
       threadState: displayThreadState,
       bindingThreadTitle: binding?.threadTitle,
       account,
@@ -6633,7 +6890,16 @@ export class CodexPluginController {
       planMode: bindingActive ? activeRun?.mode === "plan" : undefined,
       threadNote,
       permissionNote:
-        pendingProfile && activeRun
+        endpointNote
+          ? [
+              pendingProfile && activeRun
+                ? buildPendingPermissionsMigrationNote(pendingProfile)
+                : undefined,
+              endpointNote,
+            ]
+              .filter(Boolean)
+              .join(" ")
+          : pendingProfile && activeRun
           ? buildPendingPermissionsMigrationNote(pendingProfile)
           : undefined,
     });

--- a/src/format.ts
+++ b/src/format.ts
@@ -525,6 +525,7 @@ export function formatCodexContextUsageSnapshot(
 
 export function formatCodexStatusText(params: {
   pluginVersion?: string;
+  endpointId?: string;
   threadState?: ThreadState;
   bindingThreadTitle?: string;
   account?: AccountSummary | null;
@@ -549,6 +550,9 @@ export function formatCodexStatusText(params: {
   );
   if (params.pluginVersion?.trim()) {
     lines.push(`Plugin version: ${params.pluginVersion.trim()}`);
+  }
+  if (params.endpointId?.trim()) {
+    lines.push(`Endpoint: ${params.endpointId.trim()}`);
   }
   if (params.threadState) {
     lines.push(`Model: ${formatCodexModelText(params.threadState)}`);
@@ -616,6 +620,7 @@ export function formatBoundThreadSummary(params: {
     params.binding.threadTitle?.trim();
   const parts = [
     "Codex thread bound.",
+    params.binding.endpointId ? `Endpoint: ${params.binding.endpointId}` : "",
     `Project: ${projectName}`,
     threadName ? `Thread Name: ${threadName}` : "",
     `Thread ID: ${params.binding.threadId}`,

--- a/src/help.ts
+++ b/src/help.ts
@@ -147,6 +147,17 @@ export const COMMAND_HELP: Record<CommandName, CommandHelpEntry> = {
     ],
     notes: "The status card is the main interactive model-control surface, but this command remains available.",
   },
+  cas_endpoint: {
+    summary: COMMAND_SUMMARY.cas_endpoint,
+    usage: "/cas_endpoint [endpoint_id]",
+    flags: [{ flag: "[endpoint_id]", description: "Show the active endpoint or switch this conversation to a configured endpoint id." }],
+    examples: [
+      "/cas_endpoint",
+      "/cas_endpoint primary",
+      "/cas_endpoint backup",
+    ],
+    notes: "Changing the selected endpoint affects future /cas_resume and unbound CAS actions. Existing bindings stay attached to their original endpoint until you resume/bind there again.",
+  },
   cas_permissions: {
     summary: COMMAND_SUMMARY.cas_permissions,
     usage: "/cas_permissions",

--- a/src/state.ts
+++ b/src/state.ts
@@ -171,11 +171,26 @@ type PutCallbackInput =
       ttlMs?: number;
     }
   | {
+      kind: "show-endpoint-picker";
+      conversation: ConversationTarget;
+      token?: string;
+      ttlMs?: number;
+    }
+  | {
       kind: "set-model";
       conversation: ConversationTarget;
       model: string;
       returnToStatus?: boolean;
       statusMessage?: Extract<CallbackAction, { kind: "set-model" }>["statusMessage"];
+      token?: string;
+      ttlMs?: number;
+    }
+  | {
+      kind: "set-endpoint";
+      conversation: ConversationTarget;
+      endpointId: string;
+      returnToStatus?: boolean;
+      statusMessage?: Extract<CallbackAction, { kind: "set-endpoint" }>["statusMessage"];
       token?: string;
       ttlMs?: number;
     }
@@ -683,6 +698,25 @@ export class PluginStateStore {
                       ? {
                           kind: "show-model-picker",
                           conversation: callback.conversation,
+                          token: callback.token ?? this.createCallbackToken(),
+                          createdAt: now,
+                          expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
+                        }
+                    : callback.kind === "show-endpoint-picker"
+                      ? {
+                          kind: "show-endpoint-picker",
+                          conversation: callback.conversation,
+                          token: callback.token ?? this.createCallbackToken(),
+                          createdAt: now,
+                          expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),
+                        }
+                    : callback.kind === "set-endpoint"
+                      ? {
+                          kind: "set-endpoint",
+                          conversation: callback.conversation,
+                          endpointId: callback.endpointId,
+                          returnToStatus: callback.returnToStatus,
+                          statusMessage: callback.statusMessage,
                           token: callback.token ?? this.createCallbackToken(),
                           createdAt: now,
                           expiresAt: now + (callback.ttlMs ?? CALLBACK_TTL_MS),

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,6 +10,7 @@ import type {
   PermissionsMode,
   StoreSnapshot,
   StoredBinding,
+  StoredConversationEndpoint,
   StoredPendingBind,
   StoredPendingRequest,
 } from "./types.js";
@@ -18,6 +19,7 @@ type PutCallbackInput =
   | {
       kind: "start-new-thread";
       conversation: ConversationTarget;
+      endpointId?: string;
       workspaceDir: string;
       syncTopic?: boolean;
       requestedModel?: string;
@@ -29,6 +31,7 @@ type PutCallbackInput =
   | {
       kind: "resume-thread";
       conversation: ConversationTarget;
+      endpointId?: string;
       threadId: string;
       threadTitle?: string;
       workspaceDir: string;
@@ -204,6 +207,7 @@ function cloneSnapshot(value?: Partial<StoreSnapshot>): StoreSnapshot {
   return {
     version: STORE_VERSION,
     bindings: value?.bindings ?? [],
+    conversationEndpoints: value?.conversationEndpoints ?? [],
     pendingBinds: value?.pendingBinds ?? [],
     pendingRequests: value?.pendingRequests ?? [],
     callbacks: value?.callbacks ?? [],
@@ -263,6 +267,7 @@ function normalizeSnapshot(value?: Partial<StoreSnapshot>): StoreSnapshot {
       | undefined;
     return {
       ...binding,
+      endpointId: binding.endpointId?.trim() || "default",
       permissionsMode: inferPermissionsModeFromLegacyFields({
         permissionsMode: (binding as StoredBinding & { permissionsMode?: string }).permissionsMode,
         appServerProfile: (binding as StoredBinding & { appServerProfile?: string }).appServerProfile,
@@ -288,6 +293,7 @@ function normalizeSnapshot(value?: Partial<StoreSnapshot>): StoreSnapshot {
       | undefined;
     return {
       ...entry,
+      endpointId: entry.endpointId?.trim() || "default",
       permissionsMode: inferPermissionsModeFromLegacyFields({
         permissionsMode: (entry as StoredPendingBind & { permissionsMode?: string }).permissionsMode,
         appServerProfile: (entry as StoredPendingBind & { appServerProfile?: string }).appServerProfile,
@@ -297,6 +303,16 @@ function normalizeSnapshot(value?: Partial<StoreSnapshot>): StoreSnapshot {
       preferences: normalizeConversationPreferences(legacyPreferences),
     };
   });
+  snapshot.pendingRequests = snapshot.pendingRequests.map((entry) => ({
+    ...entry,
+    endpointId: entry.endpointId?.trim() || "default",
+  }));
+  snapshot.conversationEndpoints = snapshot.conversationEndpoints
+    .map((entry) => ({
+      ...entry,
+      endpointId: entry.endpointId?.trim() || "default",
+    }))
+    .filter((entry) => entry.endpointId);
   return snapshot;
 }
 
@@ -352,6 +368,24 @@ export class PluginStateStore {
   getBinding(target: ConversationTarget): StoredBinding | null {
     const key = toConversationKey(target);
     return this.snapshot.bindings.find((entry) => toConversationKey(entry.conversation) === key) ?? null;
+  }
+
+  getConversationEndpoint(target: ConversationTarget): StoredConversationEndpoint | null {
+    const key = toConversationKey(target);
+    return (
+      this.snapshot.conversationEndpoints.find(
+        (entry) => toConversationKey(entry.conversation as ConversationTarget) === key,
+      ) ?? null
+    );
+  }
+
+  async upsertConversationEndpoint(entry: StoredConversationEndpoint): Promise<void> {
+    const key = toConversationKey(entry.conversation as ConversationTarget);
+    this.snapshot.conversationEndpoints = this.snapshot.conversationEndpoints.filter(
+      (current) => toConversationKey(current.conversation as ConversationTarget) !== key,
+    );
+    this.snapshot.conversationEndpoints.push(entry);
+    await this.save();
   }
 
   async upsertBinding(binding: StoredBinding): Promise<void> {
@@ -452,6 +486,7 @@ export class PluginStateStore {
         ? {
             kind: "start-new-thread",
             conversation: callback.conversation,
+            endpointId: callback.endpointId,
             workspaceDir: callback.workspaceDir,
             syncTopic: callback.syncTopic,
             requestedModel: callback.requestedModel,
@@ -465,6 +500,7 @@ export class PluginStateStore {
         ? {
             kind: "resume-thread",
             conversation: callback.conversation,
+            endpointId: callback.endpointId,
             threadId: callback.threadId,
             threadTitle: callback.threadTitle,
             workspaceDir: callback.workspaceDir,

--- a/src/types.ts
+++ b/src/types.ts
@@ -547,9 +547,26 @@ export type CallbackAction =
     }
   | {
       token: string;
+      kind: "show-endpoint-picker";
+      conversation: ConversationRef;
+      createdAt: number;
+      expiresAt: number;
+    }
+  | {
+      token: string;
       kind: "set-model";
       conversation: ConversationRef;
       model: string;
+      returnToStatus?: boolean;
+      statusMessage?: InteractiveMessageRef;
+      createdAt: number;
+      expiresAt: number;
+    }
+  | {
+      token: string;
+      kind: "set-endpoint";
+      conversation: ConversationRef;
+      endpointId: string;
       returnToStatus?: boolean;
       statusMessage?: InteractiveMessageRef;
       createdAt: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { ConversationRef, PluginInteractiveButtons } from "openclaw/plugin-
 
 export const PLUGIN_ID = "openclaw-codex-app-server";
 export const INTERACTIVE_NAMESPACE = "codexapp";
-export const STORE_VERSION = 2;
+export const STORE_VERSION = 3;
 export const CALLBACK_TOKEN_BYTES = 9;
 export const CALLBACK_TTL_MS = 30 * 60_000;
 export const PENDING_INPUT_TTL_MS = 7 * 24 * 60 * 60_000;
@@ -11,14 +11,20 @@ export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 export type CodexTransport = "stdio" | "websocket";
 export type PermissionsMode = "default" | "full-access";
 
-export type PluginSettings = {
-  enabled: boolean;
+export type EndpointSettings = {
+  id?: string;
   transport: CodexTransport;
   command: string;
   args: string[];
   url?: string;
   headers?: Record<string, string>;
   requestTimeoutMs: number;
+};
+
+export type PluginSettings = {
+  enabled: boolean;
+  defaultEndpoint: string;
+  endpoints: EndpointSettings[];
   defaultWorkspaceDir?: string;
   defaultModel?: string;
   defaultServiceTier?: string;
@@ -274,6 +280,7 @@ export type StoredBinding = {
   conversation: ConversationRef;
   sessionKey: string;
   threadId: string;
+  endpointId?: string;
   workspaceDir: string;
   permissionsMode?: PermissionsMode;
   pendingPermissionsMode?: PermissionsMode;
@@ -299,6 +306,7 @@ export type InteractiveMessageRef =
 export type StoredPendingBind = {
   conversation: ConversationRef;
   threadId: string;
+  endpointId?: string;
   workspaceDir: string;
   permissionsMode?: PermissionsMode;
   threadTitle?: string;
@@ -312,9 +320,16 @@ export type StoredPendingRequest = {
   requestId: string;
   conversation: ConversationRef;
   threadId: string;
+  endpointId?: string;
   workspaceDir: string;
   state: PendingInputState;
   createdAt?: number;
+  updatedAt: number;
+};
+
+export type StoredConversationEndpoint = {
+  conversation: ConversationRef;
+  endpointId: string;
   updatedAt: number;
 };
 
@@ -323,6 +338,7 @@ export type CallbackAction =
       token: string;
       kind: "start-new-thread";
       conversation: ConversationRef;
+      endpointId?: string;
       workspaceDir: string;
       syncTopic?: boolean;
       requestedModel?: string;
@@ -335,6 +351,7 @@ export type CallbackAction =
       token: string;
       kind: "resume-thread";
       conversation: ConversationRef;
+      endpointId?: string;
       threadId: string;
       threadTitle?: string;
       workspaceDir: string;
@@ -375,6 +392,7 @@ export type CallbackAction =
             includeAll: boolean;
             page: number;
             syncTopic?: boolean;
+            endpointId?: string;
             query?: string;
             workspaceDir?: string;
             projectName?: string;
@@ -388,6 +406,7 @@ export type CallbackAction =
             includeAll: boolean;
             page: number;
             syncTopic?: boolean;
+            endpointId?: string;
             query?: string;
             workspaceDir?: string;
             projectName?: string;
@@ -401,6 +420,7 @@ export type CallbackAction =
             includeAll: boolean;
             page: number;
             syncTopic?: boolean;
+            endpointId?: string;
             workspaceDir?: string;
             projectName: string;
             requestedModel?: string;
@@ -563,6 +583,7 @@ export type CallbackAction =
 export type StoreSnapshot = {
   version: number;
   bindings: StoredBinding[];
+  conversationEndpoints: StoredConversationEndpoint[];
   pendingBinds: StoredPendingBind[];
   pendingRequests: StoredPendingRequest[];
   callbacks: CallbackAction[];


### PR DESCRIPTION
## Summary

Adds first-class **multi-endpoint support** to the OpenClaw Codex App Server plugin, together with **per-conversation endpoint selection**.

Closes #99.

## What’s included

- support for `defaultEndpoint` + `endpoints: []` in plugin config
- backward compatibility with the legacy single-endpoint config shape
- endpoint-aware bindings and pending bind/request state
- new `/cas_endpoint` command to inspect or switch the selected endpoint for the current conversation
- `/cas_resume` and related picker flows now operate on the selected endpoint
- `/cas_status` now shows the selected endpoint and warns when the current binding belongs to a different endpoint
- plugin schema/help/command metadata updated

## Behavior

- each conversation/topic can have a selected endpoint
- existing bindings remain attached to the endpoint they were created on
- changing the selected endpoint does **not** silently migrate an existing binding
- status makes endpoint mismatch explicit
- users can re-bind intentionally via `/cas_resume`

## Why

This makes the plugin much more practical in setups where multiple CAS backends exist, for example:

- local workstation + remote server
- different auth/account contexts
- multiple environments/projects with distinct Codex App Server instances

## Validation

Passed locally:

- `tsc --noEmit`
- `vitest run src/help.test.ts src/state.test.ts src/format.test.ts src/thread-selection.test.ts src/thread-picker.test.ts src/client.test.ts index.test.ts`

## Notes

There is still an existing environment-specific test issue around `src/controller.test.ts` importing the OpenClaw Discord SDK path in this local setup, but the implemented feature itself typechecks and the relevant test suites pass.