### PR TITLE
fix(discord): recover and isolate thread-scoped CAS bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Pre-release packages are published on matching npm dist-tags instead of `latest`
 | `/cas_status --fast`, `/cas_status --no-fast` | Change fast mode and refresh the status card. | Fast mode is only available on supported models such as GPT-5.4+. |
 | `/cas_status --yolo`, `/cas_status --no-yolo` | Change permissions mode and refresh the status card. | `--yolo` selects Full Access. |
 | `/cas_detach` | Unbind this conversation from Codex. | Stops routing plain text from this conversation into the bound thread. |
+| `/cas_reset` | Force-clear Codex state for this conversation. | Recovery command for stale binds; clears the binding plus pending bind/request/callback state, then tells you to run `/cas_resume`. |
 | `/cas_stop` | Interrupt the active Codex run. | Only applies when a turn is currently in progress. |
 | `/cas_steer <message>` | Send follow-up steer text to an active run. | Example: `/cas_steer focus on the failing tests first` |
 | `/cas_plan <goal>` | Ask Codex to plan instead of execute. | The plugin relays plan questions and the final plan back into chat. |

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 export const COMMANDS = [
   ["cas_resume", "Resume or create a Codex thread, with optional model, fast mode, and permissions overrides."],
   ["cas_detach", "Detach this conversation from the current Codex thread."],
+  ["cas_reset", "Force-clear Codex binding state for this conversation and detach it."],
   ["cas_status", "Show Codex status and controls, or apply model, fast mode, and permissions overrides."],
   ["cas_stop", "Stop the active Codex turn."],
   ["cas_steer", "Send a steer message to the active Codex turn."],

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -4046,6 +4046,129 @@ describe("Discord controller flows", () => {
     expect(startTurn).toHaveBeenCalled();
   });
 
+  it("routes Discord thread inbound claims to the thread conversation instead of the parent channel", async () => {
+    const { controller } = await createControllerHarness();
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-2",
+        parentConversationId: "channel:parent-1",
+        threadId: "thread-2",
+      },
+      sessionKey: "session-2",
+      threadId: "codex-thread-2",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    });
+    const startTurn = vi.fn(() => ({
+      result: Promise.resolve({
+        threadId: "codex-thread-2",
+        text: "hello from thread 2",
+      }),
+      getThreadId: () => "codex-thread-2",
+      queueMessage: vi.fn(async () => true),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    const result = await controller.handleInboundClaim({
+      content: "message from second discord thread",
+      channel: "discord",
+      accountId: "default",
+      conversationId: "parent-1",
+      parentConversationId: "parent-1",
+      threadId: "thread-2",
+      isGroup: true,
+      metadata: { guildId: "guild-1" },
+    });
+
+    expect(result).toEqual({ handled: true });
+    expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        binding: expect.objectContaining({
+          threadId: "codex-thread-2",
+          workspaceDir: "/repo/openclaw",
+        }),
+        conversation: expect.objectContaining({
+          conversationId: "channel:thread-2",
+          parentConversationId: "channel:parent-1",
+          threadId: "thread-2",
+        }),
+      }),
+    );
+  });
+
+  it("keeps Discord bindings for sibling threads distinct when inbound events arrive from the same parent channel", async () => {
+    const { controller } = await createControllerHarness();
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-a",
+        parentConversationId: "channel:parent-1",
+        threadId: "thread-a",
+      },
+      sessionKey: "session-a",
+      threadId: "codex-thread-a",
+      workspaceDir: "/repo/a",
+      updatedAt: Date.now(),
+    });
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-b",
+        parentConversationId: "channel:parent-1",
+        threadId: "thread-b",
+      },
+      sessionKey: "session-b",
+      threadId: "codex-thread-b",
+      workspaceDir: "/repo/b",
+      updatedAt: Date.now(),
+    });
+    const startTurn = vi.fn((params: any) => ({
+      result: Promise.resolve({
+        threadId: params.binding?.threadId ?? "unknown",
+        text: "ok",
+      }),
+      getThreadId: () => params.binding?.threadId ?? "unknown",
+      queueMessage: vi.fn(async () => true),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    const resultA = await controller.handleInboundClaim({
+      content: "from thread A",
+      channel: "discord",
+      accountId: "default",
+      conversationId: "parent-1",
+      parentConversationId: "parent-1",
+      threadId: "thread-a",
+      isGroup: true,
+      metadata: { guildId: "guild-1" },
+    });
+    const resultB = await controller.handleInboundClaim({
+      content: "from thread B",
+      channel: "discord",
+      accountId: "default",
+      conversationId: "parent-1",
+      parentConversationId: "parent-1",
+      threadId: "thread-b",
+      isGroup: true,
+      metadata: { guildId: "guild-1" },
+    });
+
+    expect(resultA).toEqual({ handled: true });
+    expect(resultB).toEqual({ handled: true });
+    expect(startTurn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ binding: expect.objectContaining({ threadId: "codex-thread-a" }) }),
+    );
+    expect(startTurn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ binding: expect.objectContaining({ threadId: "codex-thread-b" }) }),
+    );
+  });
+
   it("recovers a missing local Discord binding from the runtime binding state", async () => {
     const { controller, clientMock } = await createControllerHarness();
     await (controller as any).store.upsertConversationEndpoint({
@@ -4106,6 +4229,79 @@ describe("Discord controller flows", () => {
       endpointId: "windows-main",
       workspaceDir: "/repo/openclaw",
       permissionsMode: "full-access",
+    }));
+  });
+
+  it("recovers an approved Discord binding event when no pending local bind exists", async () => {
+    const { controller, clientMock } = await createControllerHarness();
+    const codexThreadId = "019dab3f-09f7-7a42-8d10-1f2949ce6f30";
+    conversationRuntimeState.getCurrentPluginConversationBinding.mockImplementation(async () => ({
+      bindingId: "b1",
+      pluginId: "openclaw-codex-app-server",
+      pluginRoot: "/root/.openclaw/extensions/openclaw-codex-app-server",
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:1485612939816996900",
+      parentConversationId: "channel:1485612939816996956",
+      threadId: "1485612939816996900",
+      boundAt: Date.now(),
+      summary: `Bind this conversation to Codex thread ${codexThreadId}.`,
+    } as any));
+    clientMock.readThreadState.mockResolvedValue({
+      threadId: codexThreadId,
+      threadName: "Discord Thread",
+      model: "openai/gpt-5.4",
+      cwd: "/repo/openclaw",
+      serviceTier: "default",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+    });
+
+    await controller.handleConversationBindingResolved({
+      status: "approved",
+      binding: {
+        bindingId: "binding-1",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/plugins/codex",
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1485612939816996900",
+        parentConversationId: "channel:1485612939816996956",
+        threadId: "1485612939816996900",
+        boundAt: Date.now(),
+      },
+      decision: "allow-once",
+      request: {
+        summary: `Bind this conversation to Codex thread ${codexThreadId}.`,
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel:1485612939816996900",
+          parentConversationId: "channel:1485612939816996956",
+          threadId: "1485612939816996900",
+        },
+      },
+    } as any);
+
+    expect(conversationRuntimeState.getCurrentPluginConversationBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: expect.objectContaining({
+          channel: "discord",
+          conversationId: "channel:1485612939816996900",
+          parentConversationId: "channel:1485612939816996956",
+          threadId: "1485612939816996900",
+        }),
+      }),
+    );
+    expect((controller as any).store.getBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:1485612939816996900",
+      parentConversationId: "channel:1485612939816996956",
+      threadId: "1485612939816996900",
+    })).toEqual(expect.objectContaining({
+      threadId: codexThreadId,
+      workspaceDir: "/repo/openclaw",
     }));
   });
 
@@ -4679,15 +4875,16 @@ describe("Discord controller flows", () => {
     );
   });
 
-  it("does not forward Discord thread ids into outbound adapter sends", async () => {
+  it("routes Discord thread replies through the parent channel with a thread id", async () => {
     const { controller, discordOutbound } = await createControllerHarnessWithoutLegacyDiscordRuntime();
 
     const sent = await (controller as any).sendReply(
       {
         channel: "discord",
         accountId: "default",
-        conversationId: "channel:1485612939816996956",
-        threadId: 1485612939816996900,
+        conversationId: "channel:1485612939816996900",
+        parentConversationId: "channel:1485612939816996956",
+        threadId: "1485612939816996900",
       },
       {
         text: "hello from a bound discord thread",
@@ -4700,7 +4897,7 @@ describe("Discord controller flows", () => {
       | undefined;
     expect(outboundCall?.to).toBe("channel:1485612939816996956");
     expect(outboundCall?.accountId).toBe("default");
-    expect("threadId" in (outboundCall ?? {})).toBe(false);
+    expect(outboundCall?.threadId).toBe("1485612939816996900");
   });
 
   it("restarts a Discord bound run when the active queue path fails", async () => {

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -27,6 +27,10 @@ const telegramSdkState = vi.hoisted(() => ({
   resolveTelegramAccount: vi.fn(() => ({ accountId: "default", token: "telegram-token" })),
 }));
 
+const conversationRuntimeState = vi.hoisted(() => ({
+  getCurrentPluginConversationBinding: vi.fn(async () => null),
+}));
+
 vi.mock("openclaw/plugin-sdk/discord", () => ({
   buildDiscordComponentMessage: discordSdkState.buildDiscordComponentMessage,
   editDiscordComponentMessage: discordSdkState.editDiscordComponentMessage,
@@ -36,6 +40,10 @@ vi.mock("openclaw/plugin-sdk/discord", () => ({
 
 vi.mock("openclaw/plugin-sdk/telegram-account", () => ({
   resolveTelegramAccount: telegramSdkState.resolveTelegramAccount,
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
+  getCurrentPluginConversationBinding: conversationRuntimeState.getCurrentPluginConversationBinding,
 }));
 
 function makeStateDir(): string {
@@ -553,6 +561,8 @@ beforeEach(() => {
   discordSdkState.registerBuiltDiscordComponentMessage.mockClear();
   discordSdkState.resolveDiscordAccount.mockClear();
   telegramSdkState.resolveTelegramAccount.mockClear();
+  conversationRuntimeState.getCurrentPluginConversationBinding.mockClear();
+  conversationRuntimeState.getCurrentPluginConversationBinding.mockResolvedValue(null);
   vi.spyOn(CodexAppServerClient.prototype, "logStartupProbe").mockResolvedValue();
   vi.stubGlobal(
     "fetch",
@@ -4036,8 +4046,45 @@ describe("Discord controller flows", () => {
     expect(startTurn).toHaveBeenCalled();
   });
 
-  it("does not claim inbound Discord messages when only core binding state exists", async () => {
-    const { controller } = await createControllerHarness();
+  it("recovers a missing local Discord binding from the runtime binding state", async () => {
+    const { controller, clientMock } = await createControllerHarness();
+    await (controller as any).store.upsertConversationEndpoint({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1481858418548412579",
+      },
+      endpointId: "windows-main",
+      updatedAt: Date.now(),
+    });
+    conversationRuntimeState.getCurrentPluginConversationBinding.mockImplementation(async () => ({
+      bindingId: "b1",
+      pluginId: "openclaw-codex-app-server",
+      pluginRoot: "/root/.openclaw/extensions/openclaw-codex-app-server",
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:1481858418548412579",
+      boundAt: Date.now(),
+      summary: "Bind this conversation to Codex thread 019dab3f-09f7-7a42-8d10-1f2949ce6f30.",
+    } as any));
+    clientMock.readThreadState.mockResolvedValue({
+      threadId: "019dab3f-09f7-7a42-8d10-1f2949ce6f30",
+      threadName: "Discord Thread",
+      model: "openai/gpt-5.4",
+      cwd: "/repo/openclaw",
+      serviceTier: "default",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const startTurn = vi.fn(() => ({
+      result: Promise.resolve({
+        threadId: "019dab3f-09f7-7a42-8d10-1f2949ce6f30",
+        text: "hello",
+      }),
+      getThreadId: () => "019dab3f-09f7-7a42-8d10-1f2949ce6f30",
+      queueMessage: vi.fn(async () => true),
+    }));
+    (controller as any).client.startTurn = startTurn;
 
     const result = await controller.handleInboundClaim({
       content: "who are you?",
@@ -4048,7 +4095,18 @@ describe("Discord controller flows", () => {
       metadata: { guildId: "guild-1" },
     });
 
-    expect(result).toEqual({ handled: false });
+    expect(result).toEqual({ handled: true });
+    expect(startTurn).toHaveBeenCalled();
+    expect((controller as any).store.getBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:1481858418548412579",
+    })).toEqual(expect.objectContaining({
+      threadId: "019dab3f-09f7-7a42-8d10-1f2949ce6f30",
+      endpointId: "windows-main",
+      workspaceDir: "/repo/openclaw",
+      permissionsMode: "full-access",
+    }));
   });
 
   it("uses a raw Discord channel id for the typing lease on inbound claims", async () => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -492,9 +492,8 @@ function normalizeDiscordChannelConversationId(raw?: string): string | undefined
 function resolveDiscordCommandConversation(
   ctx: PluginCommandContext,
 ): ConversationTarget | null {
-  const threadConversationId = normalizeDiscordChannelConversationId(
-    readCommandContextId(ctx, "messageThreadId"),
-  );
+  const rawThreadId = readCommandContextId(ctx, "messageThreadId");
+  const threadConversationId = normalizeDiscordChannelConversationId(rawThreadId);
   if (threadConversationId) {
     return {
       channel: "discord",
@@ -503,6 +502,7 @@ function resolveDiscordCommandConversation(
       parentConversationId: normalizeDiscordChannelConversationId(
         readCommandContextId(ctx, "threadParentId"),
       ),
+      threadId: denormalizeDiscordConversationId(threadConversationId) ?? rawThreadId,
     };
   }
   const candidates = [ctx.from, ctx.to]
@@ -575,9 +575,41 @@ function toConversationTargetFromInbound(event: {
   }
   const channel = event.channel.trim().toLowerCase();
   const conversationIdRaw = event.conversationId?.trim();
+  const parentConversationId =
+    channel === "discord"
+      ? normalizeDiscordConversationId(event.parentConversationId)
+      : event.parentConversationId;
+  const discordNormalizedThreadId =
+    channel === "discord"
+      ? (() => {
+          if (typeof event.threadId === "string") {
+            const trimmed = event.threadId.trim();
+            if (trimmed) {
+              return trimmed;
+            }
+          }
+          if (typeof event.threadId === "number" && Number.isFinite(event.threadId)) {
+            return String(Math.trunc(event.threadId));
+          }
+          return undefined;
+        })()
+      : undefined;
+  const normalizedThreadId =
+    channel === "discord"
+      ? discordNormalizedThreadId
+      : typeof event.threadId === "number"
+        ? event.threadId
+        : typeof event.threadId === "string"
+          ? Number.isFinite(Number(event.threadId))
+            ? Number(event.threadId)
+            : undefined
+          : undefined;
   const conversationId =
     channel === "discord"
       ? (() => {
+          if (discordNormalizedThreadId) {
+            return normalizeDiscordChannelConversationId(discordNormalizedThreadId);
+          }
           const normalized = normalizeDiscordConversationId(conversationIdRaw);
           if (!normalized) {
             return undefined;
@@ -591,28 +623,28 @@ function toConversationTargetFromInbound(event: {
           return `${isChannel ? "channel" : "user"}:${normalized}`;
         })()
       : event.conversationId;
-  const parentConversationId =
-    channel === "discord"
-      ? normalizeDiscordConversationId(event.parentConversationId)
-      : event.parentConversationId;
   if (!conversationId) {
     return null;
   }
+  const resolvedThreadId =
+    channel === "discord"
+      ? normalizedThreadId ?? (() => {
+          if (parentConversationId) {
+            const candidate = denormalizeDiscordConversationId(conversationId);
+            const parentRaw = denormalizeDiscordConversationId(parentConversationId);
+            if (candidate && parentRaw && candidate !== parentRaw) {
+              return candidate;
+            }
+          }
+          return undefined;
+        })()
+      : normalizedThreadId;
   return {
     channel,
     accountId: event.accountId,
     conversationId,
     parentConversationId,
-    threadId:
-      channel === "discord"
-        ? undefined
-        : typeof event.threadId === "number"
-          ? event.threadId
-          : typeof event.threadId === "string"
-            ? Number.isFinite(Number(event.threadId))
-              ? Number(event.threadId)
-              : undefined
-            : undefined,
+    threadId: resolvedThreadId,
   };
 }
 
@@ -1492,6 +1524,18 @@ export class CodexPluginController {
       conversationId: event.request.conversation.conversationId,
       parentConversationId: event.request.conversation.parentConversationId,
       threadId: (() => {
+        if (isDiscordChannel(event.request.conversation.channel)) {
+          if (typeof event.request.conversation.threadId === "string") {
+            return event.request.conversation.threadId.trim() || undefined;
+          }
+          if (
+            typeof event.request.conversation.threadId === "number" &&
+            Number.isFinite(event.request.conversation.threadId)
+          ) {
+            return String(Math.trunc(event.request.conversation.threadId));
+          }
+          return undefined;
+        }
         if (typeof event.request.conversation.threadId === "number") {
           return event.request.conversation.threadId;
         }
@@ -5086,10 +5130,12 @@ export class CodexPluginController {
       `codex discord picker send conversation=${conversation.conversationId} rows=${picker.buttons?.length ?? 0}`,
     );
     const outbound = await this.loadDiscordOutboundAdapter();
+    const discordRoute = this.resolveDiscordOutboundRoute(conversation);
     if (outbound?.sendPayload) {
       await outbound.sendPayload({
         cfg: this.getOpenClawConfig(),
-        to: conversation.conversationId,
+        to: discordRoute.to,
+        threadId: discordRoute.threadId,
         accountId: conversation.accountId,
         payload: {
           text: picker.text,
@@ -6965,10 +7011,12 @@ export class CodexPluginController {
             };
           }
         }
+        const discordRoute = this.resolveDiscordOutboundRoute(conversation);
         const result = outbound?.sendPayload
           ? await outbound.sendPayload({
               cfg: this.getOpenClawConfig(),
-              to: conversation.conversationId,
+              to: discordRoute.to,
+              threadId: discordRoute.threadId,
               accountId: conversation.accountId,
               mediaLocalRoots,
               payload: {
@@ -7063,6 +7111,27 @@ export class CodexPluginController {
       return undefined;
     }
     return (await loadAdapter("discord")) as DiscordOutboundAdapter | undefined;
+  }
+
+  private resolveDiscordOutboundRoute(conversation: ConversationTarget): {
+    to: string;
+    threadId?: string;
+  } {
+    const explicitThreadId =
+      typeof conversation.threadId === "string"
+        ? conversation.threadId.trim() || undefined
+        : typeof conversation.threadId === "number" && Number.isFinite(conversation.threadId)
+          ? String(Math.trunc(conversation.threadId))
+          : undefined;
+    const inferredThreadId =
+      conversation.parentConversationId != null
+        ? denormalizeDiscordConversationId(conversation.conversationId)
+        : undefined;
+    const threadId = explicitThreadId ?? inferredThreadId;
+    const to = threadId && conversation.parentConversationId
+      ? conversation.parentConversationId
+      : conversation.conversationId;
+    return { to, threadId };
   }
 
   private async sendTelegramTextChunk(
@@ -7189,10 +7258,12 @@ export class CodexPluginController {
   ): Promise<{ messageId: string; channelId?: string }> {
     const mediaUrl = opts?.mediaUrl;
     const mediaLocalRoots = opts?.mediaLocalRoots;
+    const discordRoute = this.resolveDiscordOutboundRoute(conversation);
     if (mediaUrl && outbound?.sendMedia) {
       return await outbound.sendMedia({
         cfg: this.getOpenClawConfig(),
-        to: conversation.conversationId,
+        to: discordRoute.to,
+        threadId: discordRoute.threadId,
         text,
         mediaUrl,
         accountId: conversation.accountId,
@@ -7202,7 +7273,8 @@ export class CodexPluginController {
     if (!mediaUrl && outbound?.sendText) {
       return await outbound.sendText({
         cfg: this.getOpenClawConfig(),
-        to: conversation.conversationId,
+        to: discordRoute.to,
+        threadId: discordRoute.threadId,
         text,
         accountId: conversation.accountId,
       });
@@ -7282,9 +7354,11 @@ export class CodexPluginController {
   }
 
   private async unbindConversation(conversation: ConversationTarget): Promise<void> {
-    const binding = this.store.getBinding(conversation);
-    if (binding?.pinnedBindingMessage) {
-      await this.unpinStoredBindingMessage(binding);
+    const bindings = this.store.listBindingsForConversationScope(conversation);
+    for (const binding of bindings) {
+      if (binding.pinnedBindingMessage) {
+        await this.unpinStoredBindingMessage(binding);
+      }
     }
     await this.store.removeBinding(conversation);
   }
@@ -7303,7 +7377,8 @@ export class CodexPluginController {
         return await legacyTyping({
           to: conversation.parentConversationId ?? conversation.conversationId,
           accountId: conversation.accountId,
-          messageThreadId: conversation.threadId,
+          messageThreadId:
+            typeof conversation.threadId === "number" ? conversation.threadId : undefined,
         });
       }
       return await this.startTelegramTypingLease(conversation);
@@ -7694,7 +7769,7 @@ export class CodexPluginController {
     conversation: ConversationTarget,
     name: string,
   ): Promise<void> {
-    if (isTelegramChannel(conversation.channel) && conversation.threadId != null) {
+    if (isTelegramChannel(conversation.channel) && typeof conversation.threadId === "number") {
       const legacyRename = this.api.runtime.channel.telegram?.conversationActions?.renameTopic;
       if (typeof legacyRename === "function") {
         await legacyRename(

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,6 +16,7 @@ import type {
   ReplyPayload,
   ConversationRef,
 } from "openclaw/plugin-sdk";
+import { getCurrentPluginConversationBinding } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolvePluginSettings, resolveWorkspaceDir } from "./config.js";
 import { CodexAppServerModeClient, type ActiveCodexRun, isMissingThreadError } from "./client.js";
 import { getThreadDisplayTitle } from "./thread-display.js";
@@ -169,6 +170,7 @@ type ActiveRunRecord = {
 };
 
 const execFileAsync = promisify(execFile);
+const PLUGIN_ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const require = createRequire(import.meta.url);
 const TEXT_ATTACHMENT_FILE_EXTENSIONS = new Set([
   ".json",
@@ -1408,6 +1410,78 @@ export class CodexPluginController {
     this.started = false;
   }
 
+  private toPluginBindingConversation(conversation: ConversationTarget): {
+    channel: string;
+    accountId: string;
+    conversationId: string;
+    parentConversationId?: string;
+    threadId?: string | number;
+  } {
+    return {
+      channel: conversation.channel,
+      accountId: conversation.accountId,
+      conversationId: conversation.conversationId,
+      parentConversationId: conversation.parentConversationId,
+      threadId: conversation.threadId,
+    };
+  }
+
+  private parseCodexThreadIdFromBindingSummary(summary?: string): string | null {
+    const trimmed = summary?.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const match = trimmed.match(/\b([0-9a-f]{8}-[0-9a-f-]{27})\b/i);
+    return match?.[1] ?? null;
+  }
+
+  private async tryRecoverMissingLocalBinding(
+    conversation: ConversationTarget,
+  ): Promise<StoredBinding | null> {
+    const runtimeBinding = await getCurrentPluginConversationBinding({
+      pluginRoot: PLUGIN_ROOT_DIR,
+      conversation: this.toPluginBindingConversation(conversation),
+    }).catch(() => null);
+    if (!runtimeBinding) {
+      return null;
+    }
+    const threadId = this.parseCodexThreadIdFromBindingSummary(runtimeBinding.summary);
+    if (!threadId) {
+      this.api.logger.debug?.(
+        `codex binding recovery skipped, runtime summary missing thread id conversation=${conversation.conversationId}`,
+      );
+      return null;
+    }
+    const threadState = await this.client
+      .readThreadState({
+        profile: "default",
+        sessionKey: buildPluginSessionKey(threadId),
+        threadId,
+      })
+      .catch(() => undefined);
+    const workspaceDir = threadState?.cwd?.trim();
+    if (!workspaceDir) {
+      this.api.logger.warn(
+        `codex binding recovery could not read workspace for conversation=${conversation.conversationId} thread=${threadId}`,
+      );
+      return null;
+    }
+    const permissionsMode =
+      threadState?.approvalPolicy?.trim() === "never" &&
+      threadState?.sandbox?.trim() === "danger-full-access"
+        ? "full-access"
+        : "default";
+    const recovered = await this.bindConversation(conversation, {
+      threadId,
+      workspaceDir,
+      threadTitle: threadState?.threadName?.trim() || undefined,
+      permissionsMode,
+    });
+    this.api.logger.warn(
+      `codex recovered missing local binding conversation=${conversation.conversationId} thread=${threadId}`,
+    );
+    return recovered;
+  }
   async handleConversationBindingResolved(
     event: PluginConversationBindingResolvedEvent,
   ): Promise<void> {
@@ -1430,6 +1504,12 @@ export class CodexPluginController {
     };
     const pending = this.store.getPendingBind(conversation);
     if (!pending) {
+      if (event.status === "approved") {
+        const recovered = await this.tryRecoverMissingLocalBinding(conversation);
+        if (recovered) {
+          return;
+        }
+      }
       this.api.logger.debug?.(
         `codex binding approved without pending local bind conversation=${conversation.conversationId}`,
       );
@@ -1541,7 +1621,11 @@ export class CodexPluginController {
       }
       const existingBinding = this.store.getBinding(conversation);
       const hydratedBinding = existingBinding ? null : await this.hydrateApprovedBinding(conversation);
-      const resolvedBinding = existingBinding ?? hydratedBinding?.binding ?? null;
+      const recoveredBinding =
+        existingBinding || hydratedBinding?.binding
+          ? null
+          : await this.tryRecoverMissingLocalBinding(conversation);
+      const resolvedBinding = existingBinding ?? hydratedBinding?.binding ?? recoveredBinding ?? null;
       this.api.logger.debug?.(
         `codex inbound claim channel=${conversation.channel} account=${conversation.accountId} conversation=${conversation.conversationId} parent=${conversation.parentConversationId ?? "<none>"} local=${resolvedBinding ? "yes" : "no"}`,
       );
@@ -1915,6 +1999,15 @@ export class CodexPluginController {
           text: detachResult?.removed
             ? "Detached this conversation from Codex."
             : "This conversation is not currently bound to Codex.",
+        };
+      case "cas_reset":
+        if (!conversation) {
+          return { text: "This command needs a Telegram or Discord conversation." };
+        }
+        await bindingApi.detachConversationBinding?.().catch(() => undefined);
+        await this.unbindConversation(conversation);
+        return {
+          text: "Reset Codex conversation state for this chat. The binding, pending requests, and stale callbacks were cleared. Run /cas_resume to bind again.",
         };
       case "cas_status":
         return await this.handleStatusCommand(

--- a/src/help.ts
+++ b/src/help.ts
@@ -43,6 +43,12 @@ export const COMMAND_HELP: Record<CommandName, CommandHelpEntry> = {
     usage: "/cas_detach",
     examples: ["/cas_detach"],
   },
+  cas_reset: {
+    summary: COMMAND_SUMMARY.cas_reset,
+    usage: "/cas_reset",
+    examples: ["/cas_reset"],
+    notes: "Use this as a recovery command when a conversation looks stuck or stale. It clears the stored binding state for this conversation, including pending bind/request UI state, and detaches from Codex.",
+  },
   cas_status: {
     summary: COMMAND_SUMMARY.cas_status,
     usage: "/cas_status [--model <name>] [--fast|--no-fast] [--yolo|--no-yolo]",

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -244,6 +244,130 @@ describe("state store", () => {
     ).toBeNull();
   });
 
+  it("clears Discord thread-scoped state even when reset is issued from the parent channel scope", async () => {
+    const store = await makeStore();
+    await store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      sessionKey: buildPluginSessionKey("thread-1"),
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+      updatedAt: Date.now(),
+    });
+    await store.upsertPendingBind({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+      updatedAt: Date.now(),
+    });
+    await store.upsertPendingRequest({
+      requestId: "req-discord-1",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+      state: {
+        requestId: "req-discord-1",
+        options: ["yes"],
+        expiresAt: Date.now() + 10_000,
+      },
+      updatedAt: Date.now(),
+    });
+    const callback = await store.putCallback({
+      kind: "resume-thread",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+    });
+
+    await store.removeBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:parent-1",
+      threadId: "thread-1",
+    });
+
+    expect(store.listBindingsForConversationScope({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:thread-1",
+    })).toHaveLength(0);
+    expect(store.getPendingBind({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:thread-1",
+    })).toBeNull();
+    expect(store.getPendingRequestById("req-discord-1")).toBeNull();
+    expect(store.getCallback(callback.token)).toBeNull();
+  });
+
+  it("does not clear sibling Discord threads that share the same parent channel", async () => {
+    const store = await makeStore();
+    await store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-1",
+        parentConversationId: "channel:parent-1",
+      },
+      sessionKey: buildPluginSessionKey("thread-1"),
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work-1",
+      updatedAt: Date.now(),
+    });
+    await store.upsertBinding({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:thread-2",
+        parentConversationId: "channel:parent-1",
+      },
+      sessionKey: buildPluginSessionKey("thread-2"),
+      threadId: "thread-2",
+      workspaceDir: "/tmp/work-2",
+      updatedAt: Date.now(),
+    });
+
+    await store.removeBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:parent-1",
+      threadId: "thread-1",
+    });
+
+    expect(store.getBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:thread-1",
+    })).toBeNull();
+    expect(store.getBinding({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:thread-2",
+    })).toEqual(expect.objectContaining({
+      sessionKey: buildPluginSessionKey("thread-2"),
+      workspaceDir: "/tmp/work-2",
+    }));
+  });
+
   it("persists conversation preferences in bindings across reload", async () => {
     const dir = await makeStoreDir();
     const store = await makeStore(dir);

--- a/src/state.ts
+++ b/src/state.ts
@@ -190,6 +190,54 @@ type PutCallbackInput =
       ttlMs?: number;
     };
 
+function normalizeDiscordConversationAlias(raw: string | number | undefined): string | undefined {
+  if (raw == null) {
+    return undefined;
+  }
+  const trimmed = String(raw).trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.startsWith("channel:") || trimmed.startsWith("user:")) {
+    return trimmed;
+  }
+  return `channel:${trimmed}`;
+}
+
+function getConversationScopeAliases(target: ConversationTarget): Set<string> {
+  const aliases = new Set<string>();
+  const conversationId = target.conversationId.trim();
+  if (conversationId) {
+    aliases.add(conversationId);
+  }
+  if (target.channel.trim().toLowerCase() !== "discord") {
+    return aliases;
+  }
+  const threadConversationId = normalizeDiscordConversationAlias(target.threadId);
+  if (threadConversationId) {
+    aliases.add(threadConversationId);
+  }
+  return aliases;
+}
+
+function matchesConversationScope(target: ConversationTarget, candidate: ConversationTarget): boolean {
+  const targetChannel = target.channel.trim().toLowerCase();
+  if (targetChannel !== candidate.channel.trim().toLowerCase()) {
+    return false;
+  }
+  if (target.accountId.trim() !== candidate.accountId.trim()) {
+    return false;
+  }
+  if (targetChannel !== "discord") {
+    return toConversationKey(target) === toConversationKey(candidate);
+  }
+  const aliases = getConversationScopeAliases(target);
+  if (aliases.size === 0) {
+    return false;
+  }
+  return aliases.has(candidate.conversationId.trim());
+}
+
 function toConversationKey(target: ConversationTarget): string {
   const channel = target.channel.trim().toLowerCase();
   return [
@@ -349,6 +397,12 @@ export class PluginStateStore {
     return [...this.snapshot.bindings];
   }
 
+  listBindingsForConversationScope(target: ConversationTarget): StoredBinding[] {
+    return this.snapshot.bindings.filter((entry) =>
+      matchesConversationScope(target, entry.conversation as ConversationTarget),
+    );
+  }
+
   getBinding(target: ConversationTarget): StoredBinding | null {
     const key = toConversationKey(target);
     return this.snapshot.bindings.find((entry) => toConversationKey(entry.conversation) === key) ?? null;
@@ -367,18 +421,17 @@ export class PluginStateStore {
   }
 
   async removeBinding(target: ConversationTarget): Promise<void> {
-    const key = toConversationKey(target);
     this.snapshot.bindings = this.snapshot.bindings.filter(
-      (entry) => toConversationKey(entry.conversation) !== key,
+      (entry) => !matchesConversationScope(target, entry.conversation as ConversationTarget),
     );
     this.snapshot.pendingBinds = this.snapshot.pendingBinds.filter(
-      (entry) => toConversationKey(entry.conversation) !== key,
+      (entry) => !matchesConversationScope(target, entry.conversation as ConversationTarget),
     );
     this.snapshot.pendingRequests = this.snapshot.pendingRequests.filter(
-      (entry) => toConversationKey(entry.conversation) !== key,
+      (entry) => !matchesConversationScope(target, entry.conversation as ConversationTarget),
     );
     this.snapshot.callbacks = this.snapshot.callbacks.filter(
-      (entry) => toConversationKey(entry.conversation) !== key,
+      (entry) => !matchesConversationScope(target, entry.conversation as ConversationTarget),
     );
     await this.save();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -569,7 +569,7 @@ export type StoreSnapshot = {
 };
 
 export type ConversationTarget = ConversationRef & {
-  threadId?: number;
+  threadId?: number | string;
 };
 
 export type CommandButtons = PluginInteractiveButtons;


### PR DESCRIPTION
## Summary
- recover missing local Discord CAS bindings when core still has the runtime binding
- scope Discord thread bindings by thread id to avoid cross-thread collisions
- document `/cas_reset` as the recovery command for stale thread state

## Validation
- `tsc --noEmit`
- `vitest run src/state.test.ts`
- `vitest run src/controller.test.ts` *(currently fails on repo baseline because of missing `openclaw/plugin-sdk/discord` export in test env)*