### PR TITLE
Fix Telegram DM session binding key mismatch and stale binding cleanup

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -62,6 +62,18 @@ describe("resolvePluginSettings", () => {
     expect(resolvePluginSettings({}).command).toBe(path.join(localBin, "codex"));
   });
 
+  it("keeps PATH order when multiple home-local codex binaries exist", () => {
+    const homeDir = makeTempHome();
+    const localBin = path.join(homeDir, ".local", "bin");
+    const asdfBin = path.join(homeDir, ".asdf", "shims");
+    writeExecutable(path.join(localBin, "codex"));
+    writeExecutable(path.join(asdfBin, "codex"));
+    process.env.HOME = homeDir;
+    process.env.PATH = [asdfBin, localBin, "/usr/bin"].join(path.delimiter);
+
+    expect(resolvePluginSettings({}).command).toBe(path.join(asdfBin, "codex"));
+  });
+
   it("falls back to bare codex when no preferred user-local binary exists", () => {
     const homeDir = makeTempHome();
     process.env.HOME = homeDir;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePluginSettings } from "./config.js";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_PATH = process.env.PATH;
+const ORIGINAL_XDG_BIN_HOME = process.env.XDG_BIN_HOME;
+
+function restoreEnv(key: "HOME" | "PATH" | "XDG_BIN_HOME", value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+function makeTempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-config-"));
+}
+
+function writeExecutable(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "#!/bin/sh\nexit 0\n", "utf8");
+  fs.chmodSync(filePath, 0o755);
+}
+
+afterEach(() => {
+  restoreEnv("HOME", ORIGINAL_HOME);
+  restoreEnv("PATH", ORIGINAL_PATH);
+  restoreEnv("XDG_BIN_HOME", ORIGINAL_XDG_BIN_HOME);
+});
+
+describe("resolvePluginSettings", () => {
+  it("keeps an explicit command when one is configured", () => {
+    const homeDir = makeTempHome();
+    writeExecutable(path.join(homeDir, ".local", "bin", "codex"));
+    process.env.HOME = homeDir;
+
+    expect(resolvePluginSettings({ command: "/custom/codex" }).command).toBe("/custom/codex");
+  });
+
+  it("prefers XDG_BIN_HOME when command is omitted", () => {
+    const homeDir = makeTempHome();
+    const xdgBinHome = path.join(homeDir, "xdg-bin");
+    writeExecutable(path.join(xdgBinHome, "codex"));
+    process.env.HOME = homeDir;
+    process.env.XDG_BIN_HOME = xdgBinHome;
+    process.env.PATH = "/usr/bin";
+
+    expect(resolvePluginSettings({}).command).toBe(path.join(xdgBinHome, "codex"));
+  });
+
+  it("prefers a user-local codex binary before falling back to bare codex", () => {
+    const homeDir = makeTempHome();
+    const localBin = path.join(homeDir, ".local", "bin");
+    writeExecutable(path.join(localBin, "codex"));
+    process.env.HOME = homeDir;
+    process.env.PATH = "/usr/bin";
+
+    expect(resolvePluginSettings({}).command).toBe(path.join(localBin, "codex"));
+  });
+
+  it("falls back to bare codex when no preferred user-local binary exists", () => {
+    const homeDir = makeTempHome();
+    process.env.HOME = homeDir;
+    process.env.PATH = "/usr/bin";
+    delete process.env.XDG_BIN_HOME;
+
+    expect(resolvePluginSettings({}).command).toBe("codex");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { accessSync, constants } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { PluginSettings } from "./types.js";
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
@@ -56,10 +59,90 @@ function readNumber(
   return fallback;
 }
 
+function listExecutableNames(command: string): string[] {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+  if (path.extname(command)) {
+    return [command];
+  }
+  const extensions = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return [command, ...extensions.map((extension) => `${command}${extension.toLowerCase()}`)];
+}
+
+function isExecutableFile(candidate: string): boolean {
+  try {
+    accessSync(candidate, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveExecutableInDir(dir: string, command: string): string | undefined {
+  for (const executableName of listExecutableNames(command)) {
+    const candidate = path.join(dir, executableName);
+    if (isExecutableFile(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function uniqueDirs(entries: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    const trimmed = entry?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const resolved = path.resolve(trimmed);
+    if (seen.has(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    dirs.push(resolved);
+  }
+  return dirs;
+}
+
+function resolveDefaultStdioCommand(): string | undefined {
+  const command = "codex";
+  const homeDir = os.homedir().trim();
+  const pathDirs = (process.env.PATH || "")
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const homePathDirs = homeDir
+    ? pathDirs.filter((entry) => {
+        const resolved = path.resolve(entry);
+        return resolved === homeDir || resolved.startsWith(`${homeDir}${path.sep}`);
+      })
+    : [];
+  const candidateDirs = uniqueDirs([
+    process.env.XDG_BIN_HOME,
+    homeDir ? path.join(homeDir, ".local", "bin") : undefined,
+    homeDir ? path.join(homeDir, "bin") : undefined,
+    ...homePathDirs,
+  ]);
+  for (const dir of candidateDirs) {
+    const resolved = resolveExecutableInDir(dir, command);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
 export function resolvePluginSettings(rawConfig: unknown): PluginSettings {
   const record = asRecord(rawConfig);
   const transport = record.transport === "websocket" ? "websocket" : "stdio";
   const authToken = readString(record, "authToken");
+  const configuredCommand = readString(record, "command");
   const configuredHeaders = readHeaders(record);
   const headers = {
     ...(configuredHeaders ?? {}),
@@ -69,7 +152,7 @@ export function resolvePluginSettings(rawConfig: unknown): PluginSettings {
   return {
     enabled: record.enabled !== false,
     transport,
-    command: readString(record, "command") ?? "codex",
+    command: configuredCommand ?? resolveDefaultStdioCommand() ?? "codex",
     args: readStringArray(record, "args"),
     url: readString(record, "url"),
     headers: Object.keys(headers).length > 0 ? headers : undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,10 +124,10 @@ function resolveDefaultStdioCommand(): string | undefined {
       })
     : [];
   const candidateDirs = uniqueDirs([
+    ...homePathDirs,
     process.env.XDG_BIN_HOME,
     homeDir ? path.join(homeDir, ".local", "bin") : undefined,
     homeDir ? path.join(homeDir, "bin") : undefined,
-    ...homePathDirs,
   ]);
   for (const dir of candidateDirs) {
     const resolved = resolveExecutableInDir(dir, command);

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -4051,6 +4051,46 @@ describe("Discord controller flows", () => {
     expect(result).toEqual({ handled: false });
   });
 
+  it("claims inbound Telegram topic messages when the event carries chat id plus thread id", async () => {
+    const { controller } = await createControllerHarness();
+    await (controller as any).store.upsertBinding({
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "123:topic:456",
+        parentConversationId: "123",
+      },
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    });
+    const startTurn = vi.fn(() => ({
+      result: Promise.resolve({
+        threadId: "thread-1",
+        text: "hello",
+      }),
+      getThreadId: () => "thread-1",
+      queueMessage: vi.fn(async () => true),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    const result = await controller.handleInboundClaim({
+      content: "There?",
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123",
+      threadId: 456,
+    });
+
+    expect(result).toEqual({ handled: true });
+    expect(startTurn).toHaveBeenCalled();
+  });
+
   it("uses a raw Discord channel id for the typing lease on inbound claims", async () => {
     const { controller, discordTypingStart } = await createControllerHarness();
     await (controller as any).store.upsertBinding({

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -2429,6 +2429,47 @@ describe("Discord controller flows", () => {
     );
   });
 
+  it("does not restore a dead binding when cas_status applies overrides", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      preferences: {
+        preferredModel: "openai/gpt-5.4",
+        updatedAt: Date.now(),
+      },
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildTelegramCommandContext({
+        args: "--model openai/gpt-5.4-mini",
+        commandBody: "/cas_status --model openai/gpt-5.4-mini",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
+      }),
+    );
+
+    expect(reply).toEqual({
+      text: "Bind this conversation to Codex before changing status settings.",
+    });
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex clearing stale binding"),
+    );
+  });
+
   it("hides the fast button on status controls when the current model does not support it", async () => {
     const { controller, sendMessageTelegram } = await createControllerHarness();
     await (controller as any).store.upsertBinding({

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -2377,6 +2377,58 @@ describe("Discord controller flows", () => {
     expect(buttons[1][1].text).toBe("Permissions: toggle");
   });
 
+  it("clears a dead binding when status reads hit a missing thread", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+    await (controller as any).store.upsertPendingRequest({
+      requestId: "pending-1",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      state: {
+        requestId: "pending-1",
+        options: ["Approve Once", "Cancel"],
+        expiresAt: Date.now() + 60_000,
+      },
+      updatedAt: Date.now(),
+    });
+    const callback = await (controller as any).store.putCallback({
+      kind: "refresh-status",
+      conversation,
+    });
+
+    const reply = await controller.handleCommand(
+      "cas_status",
+      buildTelegramCommandContext({
+        commandBody: "/cas_status",
+        getCurrentConversationBinding: vi.fn(async () => ({ bindingId: "b1" })),
+      }),
+    );
+
+    expect(reply.text).toContain("Binding: none");
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
+    expect((controller as any).store.getPendingRequestByConversation(conversation)).toBeNull();
+    expect((controller as any).store.getCallback(callback.token)).toBeNull();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex clearing stale binding"),
+    );
+  });
+
   it("hides the fast button on status controls when the current model does not support it", async () => {
     const { controller, sendMessageTelegram } = await createControllerHarness();
     await (controller as any).store.upsertBinding({
@@ -4841,6 +4893,50 @@ describe("Discord controller flows", () => {
     expect(staleQueueMessage).not.toHaveBeenCalled();
     expect(staleInterrupt).toHaveBeenCalled();
     expect(startTurn).toHaveBeenCalled();
+  });
+
+  it("drops a dead bound thread before starting a new turn", async () => {
+    const { controller, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:chan-1",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(
+      new Error("codex app server rpc error (-32600): no rollout found for thread id thread-1"),
+    );
+    await (controller as any).store.upsertBinding(binding);
+    const startTurn = vi.fn(() => ({
+      result: new Promise(() => {}),
+      getThreadId: () => undefined,
+      queueMessage: vi.fn(async () => true),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    await (controller as any).startTurn({
+      conversation,
+      binding,
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "command",
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: undefined,
+      existingThreadId: undefined,
+    }));
+    expect((controller as any).store.getBinding(conversation)).toBeNull();
   });
 
   it("does not send the plan keepalive after a questionnaire is already visible", async () => {

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -3818,6 +3818,64 @@ describe("Discord controller flows", () => {
     });
   });
 
+  it("clears sibling resume-thread callbacks once a resume selection enters pending approval", async () => {
+    const { controller } = await createControllerHarness();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:456",
+      parentConversationId: "123",
+    } as const;
+    const first = await (controller as any).store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+    });
+    const second = await (controller as any).store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-2",
+      workspaceDir: "/repo/openclaw",
+    });
+    const pickerView = await (controller as any).store.putCallback({
+      kind: "picker-view",
+      conversation,
+      view: {
+        mode: "threads",
+        page: 0,
+      },
+    });
+
+    await controller.handleTelegramInteractive({
+      ...conversation,
+      threadId: 456,
+      requestConversationBinding: vi.fn(async () => ({
+        status: "pending" as const,
+        reply: {
+          text: "Plugin bind approval required",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Allow once", callback_data: "pluginbind:approval:o" }]],
+            },
+          },
+        },
+      })),
+      callback: {
+        payload: first.token,
+      },
+      respond: {
+        clearButtons: vi.fn(async () => {}),
+        reply: vi.fn(async () => {}),
+        editMessage: vi.fn(async () => {}),
+      },
+    } as any);
+
+    expect((controller as any).store.getCallback(first.token)).toBeNull();
+    expect((controller as any).store.getCallback(second.token)).toBeNull();
+    expect((controller as any).store.getCallback(pickerView.token)?.kind).toBe("picker-view");
+  });
+
   it("renders Telegram bind approval buttons from interactive reply blocks", async () => {
     const { controller } = await createControllerHarness();
     const callback = await (controller as any).store.putCallback({

--- a/src/controller.test.ts
+++ b/src/controller.test.ts
@@ -5038,6 +5038,56 @@ describe("Discord controller flows", () => {
     expect((controller as any).store.getBinding(conversation)).toBeNull();
   });
 
+  it("keeps the saved binding when preflight thread verification fails for a generic error", async () => {
+    const { controller, api, clientMock } = await createControllerHarness();
+    const conversation = {
+      channel: "discord",
+      accountId: "default",
+      conversationId: "channel:chan-1",
+    } as const;
+    const binding = {
+      conversation,
+      sessionKey: "session-1",
+      threadId: "thread-1",
+      workspaceDir: "/repo/openclaw",
+      updatedAt: Date.now(),
+    };
+    clientMock.readThreadState.mockRejectedValue(new Error("rpc timeout"));
+    await (controller as any).store.upsertBinding(binding);
+    const startTurn = vi.fn(() => ({
+      result: new Promise(() => {}),
+      getThreadId: () => undefined,
+      queueMessage: vi.fn(async () => true),
+      interrupt: vi.fn(async () => {}),
+      isAwaitingInput: () => false,
+      submitPendingInput: vi.fn(async () => false),
+      submitPendingInputPayload: vi.fn(async () => false),
+    }));
+    (controller as any).client.startTurn = startTurn;
+
+    await (controller as any).startTurn({
+      conversation,
+      binding,
+      workspaceDir: "/repo/openclaw",
+      prompt: "who are you?",
+      reason: "command",
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: "session-1",
+      existingThreadId: "thread-1",
+    }));
+    expect((controller as any).store.getBinding(conversation)).toEqual(
+      expect.objectContaining({
+        sessionKey: "session-1",
+        threadId: "thread-1",
+      }),
+    );
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("codex could not verify bound thread before start turn (command)"),
+    );
+  });
+
   it("does not send the plan keepalive after a questionnaire is already visible", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-23T13:10:00-04:00"));

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -168,6 +168,19 @@ type ActiveRunRecord = {
   handle: ActiveCodexRun;
 };
 
+function isPreMaterializedThreadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.trim().toLowerCase();
+  return (
+    normalized.includes("not materialized yet") ||
+    normalized.includes("includeturns is unavailable before first user message")
+  );
+}
+
+function shouldClearBindingForThreadError(error: unknown): boolean {
+  return isMissingThreadError(error) && !isPreMaterializedThreadError(error);
+}
+
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const TEXT_ATTACHMENT_FILE_EXTENSIONS = new Set([
@@ -2316,6 +2329,18 @@ export class CodexPluginController {
     return getBindingPermissionsMode(binding ?? null);
   }
 
+  private toConversationTarget(
+    conversation: StoredBinding["conversation"] | ConversationTarget,
+  ): ConversationTarget {
+    return {
+      channel: conversation.channel,
+      accountId: conversation.accountId,
+      conversationId: conversation.conversationId,
+      parentConversationId: conversation.parentConversationId,
+      threadId: "threadId" in conversation ? conversation.threadId : undefined,
+    };
+  }
+
   private async waitForActiveRunToClear(
     conversation: ConversationTarget,
     timeoutMs = 3_000,
@@ -2331,6 +2356,40 @@ export class CodexPluginController {
     return !this.activeRuns.has(key);
   }
 
+  private async clearStaleBinding(binding: StoredBinding, reason: string): Promise<void> {
+    const conversation = this.toConversationTarget(binding.conversation);
+    this.api.logger.warn(
+      `codex clearing stale binding ${this.formatConversationForLog(conversation)} thread=${binding.threadId} reason=${reason}`,
+    );
+    await this.unbindConversation(conversation);
+  }
+
+  private async ensureUsableBindingForTurn(
+    binding: StoredBinding | null,
+    reason: string,
+  ): Promise<StoredBinding | null> {
+    if (!binding) {
+      return null;
+    }
+    try {
+      await this.client.readThreadState({
+        profile: this.getPermissionsMode(binding),
+        sessionKey: binding.sessionKey,
+        threadId: binding.threadId,
+      });
+      return binding;
+    } catch (error) {
+      if (!shouldClearBindingForThreadError(error)) {
+        if (isMissingThreadError(error)) {
+          return binding;
+        }
+        throw error;
+      }
+      await this.clearStaleBinding(binding, reason);
+      return null;
+    }
+  }
+
   private async readEffectiveThreadState(binding: StoredBinding): Promise<{
     state: ThreadState | undefined;
     effectiveState: ThreadState | undefined;
@@ -2340,7 +2399,12 @@ export class CodexPluginController {
       profile,
       sessionKey: binding.sessionKey,
       threadId: binding.threadId,
-    }).catch(() => undefined);
+    }).catch(async (error) => {
+      if (shouldClearBindingForThreadError(error)) {
+        await this.clearStaleBinding(binding, "read effective thread state");
+      }
+      return undefined;
+    });
     const desired = buildDesiredThreadConfiguration(state, binding);
     return {
       state,
@@ -2419,7 +2483,12 @@ export class CodexPluginController {
         profile,
         sessionKey: binding.sessionKey,
         threadId: binding.threadId,
-      }).catch(() => undefined));
+      }).catch(async (error) => {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, opts?.context ?? "reconcile thread settings");
+        }
+        return undefined;
+      }));
     let desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
     if (desired.model && desired.model !== state?.model?.trim()) {
       try {
@@ -2431,6 +2500,10 @@ export class CodexPluginController {
         });
         desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} model`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} model: ${String(error)}`,
         );
@@ -2448,6 +2521,10 @@ export class CodexPluginController {
         });
         desired = buildDesiredThreadConfiguration(state, binding, opts?.modelFallback);
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} fast mode`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} fast mode: ${String(error)}`,
         );
@@ -2471,6 +2548,10 @@ export class CodexPluginController {
           sandbox: desired.sandbox,
         });
       } catch (error) {
+        if (shouldClearBindingForThreadError(error)) {
+          await this.clearStaleBinding(binding, `${opts?.context ?? "reconcile thread settings"} permissions`);
+          return state;
+        }
         this.api.logger.warn(
           `codex failed to ${opts?.context ?? "reconcile thread settings"} permissions: ${String(error)}`,
         );
@@ -2799,12 +2880,16 @@ export class CodexPluginController {
     bindingActive: boolean,
   ): Promise<StatusCardRender> {
     const text = await this.buildStatusText(conversation, binding, bindingActive);
-    if (!conversation || !binding || !bindingActive) {
+    const currentBinding =
+      binding && conversation
+        ? this.store.getBinding(this.toConversationTarget(binding.conversation))
+        : binding;
+    if (!conversation || !currentBinding || !bindingActive) {
       return { text };
     }
     return {
       text,
-      buttons: await this.buildStatusControlButtons(conversation, binding),
+      buttons: await this.buildStatusControlButtons(conversation, currentBinding),
     };
   }
 
@@ -3488,8 +3573,12 @@ export class CodexPluginController {
     reason: "command" | "inbound" | "plan";
     collaborationMode?: CollaborationMode;
   }): Promise<void> {
+    const binding = await this.ensureUsableBindingForTurn(
+      params.binding,
+      `start turn (${params.reason})`,
+    );
     const key = buildConversationKey(params.conversation);
-    const profile = this.getPermissionsMode(params.binding);
+    const profile = this.getPermissionsMode(binding);
     const existing = this.activeRuns.get(key);
     this.api.logger.debug?.(
       `codex turn request reason=${params.reason} ${this.formatConversationForLog(params.conversation)} workspace=${params.workspaceDir} existing=${existing ? existing.mode : "none"} profile=${profile} prompt="${summarizeTextForLog(params.prompt)}"`,
@@ -3530,21 +3619,21 @@ export class CodexPluginController {
     }
     const typing = await this.startTypingLease(params.conversation);
     this.api.logger.debug?.(
-      `codex turn starting app-server run ${this.formatConversationForLog(params.conversation)} typing=${typing ? "yes" : "no"} session=${params.binding?.sessionKey ?? "<none>"} existingThread=${params.binding?.threadId ?? "<none>"} profile=${profile} mode=${params.collaborationMode?.mode ?? "default"}`,
+      `codex turn starting app-server run ${this.formatConversationForLog(params.conversation)} typing=${typing ? "yes" : "no"} session=${binding?.sessionKey ?? "<none>"} existingThread=${binding?.threadId ?? "<none>"} profile=${profile} mode=${params.collaborationMode?.mode ?? "default"}`,
     );
     const desired = buildDesiredThreadConfiguration(
       undefined,
-      params.binding,
+      binding,
       this.settings.defaultModel,
     );
     const run = this.client.startTurn({
       profile,
-      sessionKey: params.binding?.sessionKey,
+      sessionKey: binding?.sessionKey,
       workspaceDir: params.workspaceDir,
       prompt: params.prompt,
       input: params.input,
       runId: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
-      existingThreadId: params.binding?.threadId,
+      existingThreadId: binding?.threadId,
       model: desired.model,
       reasoningEffort: desired.reasoningEffort,
       serviceTier: desired.serviceTier ?? undefined,
@@ -3584,7 +3673,7 @@ export class CodexPluginController {
           const state = await this.client
             .readThreadState({
               profile,
-              sessionKey: params.binding?.sessionKey,
+              sessionKey: binding?.sessionKey,
               threadId,
             })
             .catch(() => null);
@@ -3615,7 +3704,7 @@ export class CodexPluginController {
         const completionText =
           result.terminalStatus === "failed"
             ? await this.describeTurnFailure({
-            sessionKey: params.binding?.sessionKey,
+            sessionKey: binding?.sessionKey,
             profile,
             error: result.terminalError?.message ?? "turn failed",
             terminalError: result.terminalError,
@@ -3636,7 +3725,7 @@ export class CodexPluginController {
         await this.sendText(
           params.conversation,
           await this.describeTurnFailure({
-            sessionKey: params.binding?.sessionKey,
+            sessionKey: binding?.sessionKey,
             profile,
             error,
           }),
@@ -6452,10 +6541,8 @@ export class CodexPluginController {
       }
     };
 
-    const [initialState, replay] = await Promise.all([
-      readStateForRestore(),
-      readReplayForRestore(),
-    ]);
+    const initialState = await readStateForRestore();
+    const replay = await readReplayForRestore();
     const state =
       (await this.reconcileThreadConfiguration(binding, {
         threadState: initialState,
@@ -6590,7 +6677,12 @@ export class CodexPluginController {
             profile,
             sessionKey: binding.sessionKey,
             threadId: binding.threadId,
-          }).catch(() => undefined)
+          }).catch(async (error) => {
+            if (shouldClearBindingForThreadError(error)) {
+              await this.clearStaleBinding(binding, "build status text");
+            }
+            return undefined;
+          })
         : Promise.resolve(undefined),
       this.client.readAccount({
         profile,
@@ -6602,35 +6694,40 @@ export class CodexPluginController {
       }).catch(() => []),
       this.resolveProjectFolder(binding?.workspaceDir || workspaceDir),
     ]);
-    const effectiveThreadState = buildDesiredThreadConfiguration(threadState, binding).effectiveState;
+    const currentBinding =
+      binding && conversation
+        ? this.store.getBinding(this.toConversationTarget(binding.conversation))
+        : binding;
+    const currentBindingActive = bindingActive && Boolean(currentBinding);
+    const effectiveThreadState = buildDesiredThreadConfiguration(threadState, currentBinding).effectiveState;
     const displayThreadState =
       effectiveThreadState ??
-      (binding
+      (currentBinding
         ? {
-            threadId: binding.threadId,
-            threadName: binding.threadTitle,
-            cwd: binding.workspaceDir,
+            threadId: currentBinding.threadId,
+            threadName: currentBinding.threadTitle,
+            cwd: currentBinding.workspaceDir,
           }
         : undefined);
     const threadNote =
-      binding && !threadState
+      currentBinding && !threadState
         ? "Live thread details are unavailable until Codex materializes the thread, usually after the first user message. Model, reasoning, and fast-mode changes made here are saved as defaults until then."
         : undefined;
     this.api.logger.debug?.(
-      `codex status snapshot bindingActive=${bindingActive ? "yes" : "no"} activeRun=${activeRun?.mode ?? "none"} boundThread=${binding?.threadId ?? "<none>"} raw=${formatThreadStateForLog(threadState)} effective=${formatThreadStateForLog(displayThreadState)} ${formatBindingPreferencesForLog(binding)} threadCwd=${displayThreadState?.cwd?.trim() || "<none>"}`,
+      `codex status snapshot bindingActive=${currentBindingActive ? "yes" : "no"} activeRun=${activeRun?.mode ?? "none"} boundThread=${currentBinding?.threadId ?? "<none>"} raw=${formatThreadStateForLog(threadState)} effective=${formatThreadStateForLog(displayThreadState)} ${formatBindingPreferencesForLog(currentBinding)} threadCwd=${displayThreadState?.cwd?.trim() || "<none>"}`,
     );
 
     return formatCodexStatusText({
       pluginVersion: PLUGIN_VERSION,
       threadState: displayThreadState,
-      bindingThreadTitle: binding?.threadTitle,
+      bindingThreadTitle: currentBinding?.threadTitle,
       account,
       rateLimits: limits,
-      bindingActive,
+      bindingActive: currentBindingActive,
       projectFolder,
-      worktreeFolder: displayThreadState?.cwd?.trim() || binding?.workspaceDir || workspaceDir,
-      contextUsage: binding?.contextUsage,
-      planMode: bindingActive ? activeRun?.mode === "plan" : undefined,
+      worktreeFolder: displayThreadState?.cwd?.trim() || currentBinding?.workspaceDir || workspaceDir,
+      contextUsage: currentBinding?.contextUsage,
+      planMode: currentBindingActive ? activeRun?.mode === "plan" : undefined,
       threadNote,
       permissionNote:
         pendingProfile && activeRun

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2388,10 +2388,10 @@ export class CodexPluginController {
       return binding;
     } catch (error) {
       if (!shouldClearBindingForThreadError(error)) {
-        if (isMissingThreadError(error)) {
-          return binding;
-        }
-        throw error;
+        this.api.logger.warn(
+          `codex could not verify bound thread before ${reason} ${this.formatConversationForLog(this.toConversationTarget(binding.conversation))} thread=${binding.threadId}: ${String(error)}`,
+        );
+        return binding;
       }
       await this.clearStaleBinding(binding, reason);
       return null;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -639,9 +639,11 @@ function toConversationTargetFromInbound(event: {
   const parentConversationId =
     channel === "discord"
       ? normalizeDiscordConversationId(event.parentConversationId)
-      : channel === "telegram" && telegramThreadId != null
-        ? normalizeTelegramChatId(event.parentConversationId) ??
-          normalizeTelegramChatId(conversationIdRaw)?.split(":topic:")[0]
+      : channel === "telegram"
+        ? telegramThreadId != null
+          ? normalizeTelegramChatId(event.parentConversationId) ??
+            normalizeTelegramChatId(conversationIdRaw)?.split(":topic:")[0]
+          : undefined  // DM: no topic, parentConversationId not needed for key matching
       : event.parentConversationId;
   if (!conversationId) {
     return null;
@@ -1590,6 +1592,29 @@ export class CodexPluginController {
         `codex inbound claim channel=${conversation.channel} account=${conversation.accountId} conversation=${conversation.conversationId} parent=${conversation.parentConversationId ?? "<none>"} local=${resolvedBinding ? "yes" : "no"}`,
       );
       if (!resolvedBinding) {
+        // Check if OpenClaw still has us registered as the handler for this conversation.
+        // If so, our internal state was cleared (stale thread) without properly detaching from
+        // OpenClaw. Detach now and notify the user so they can run /cas_resume.
+        const conversationRef = {
+          channel: conversation.channel,
+          accountId: conversation.accountId,
+          conversationId: conversation.conversationId,
+        };
+        const sessionBindingSvc = await this.loadSessionBindingService().catch(() => null);
+        const activeBinding = sessionBindingSvc?.resolveByConversation(conversationRef) ?? null;
+        if (activeBinding) {
+          this.api.logger.warn(
+            `codex inbound claim detaching stale openclaw binding ${this.formatConversationForLog(conversation)}`,
+          );
+          await sessionBindingSvc!
+            .unbind({ bindingId: activeBinding.bindingId, reason: "stale-cleared" })
+            .catch(() => undefined);
+          await this.sendText(
+            conversation,
+            "\u26a0\ufe0f Codex session expired. Run /cas_resume to start a new thread.",
+          ).catch(() => undefined);
+          return { handled: true };
+        }
         return { handled: false };
       }
       if (hydratedBinding?.pendingBind?.syncTopic) {
@@ -5259,6 +5284,26 @@ export class CodexPluginController {
       }
       return undefined;
     }
+  }
+
+
+  private async loadSessionBindingService(): Promise<{
+    resolveByConversation: (ref: { channel: string; accountId: string; conversationId: string }) => { bindingId: string } | null;
+    unbind: (input: { bindingId: string; reason?: string }) => Promise<unknown>;
+  }> {
+    type SessionBindingRuntimeModule = {
+      getSessionBindingService: () => {
+        resolveByConversation: (ref: { channel: string; accountId: string; conversationId: string }) => { bindingId: string } | null;
+        unbind: (input: { bindingId: string; reason?: string }) => Promise<unknown>;
+      };
+    };
+    const mod = await loadOpenClawCompatModule<SessionBindingRuntimeModule>({
+      specifier: "openclaw/plugin-sdk/session-binding-runtime",
+      fallbackRelativePath: "dist/plugin-sdk/session-binding-runtime.js",
+      label: "session-binding-runtime",
+      logger: this.api.logger,
+    });
+    return mod.getSessionBindingService();
   }
 
   private async loadDiscordSdk(): Promise<DiscordSdkModule> {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5390,6 +5390,9 @@ export class CodexPluginController {
         responders.requestConversationBinding,
       );
       if (bindResult.status === "pending") {
+        await this.store.removeConversationCallbacks(callback.conversation, {
+          kinds: ["resume-thread"],
+        });
         // Interactive bind requests already send the approval prompt with the
         // channel-specific buttons/components from responders.requestConversationBinding.
         // Sending another plain-text reply here duplicates the same prompt.
@@ -5399,7 +5402,9 @@ export class CodexPluginController {
         await responders.reply(bindResult.message);
         return;
       }
-      await this.store.removeCallback(callback.token);
+      await this.store.removeConversationCallbacks(callback.conversation, {
+        kinds: ["resume-thread"],
+      });
       if (callback.syncTopic) {
         const syncedName = buildResumeTopicName({
           title: threadState?.threadName?.trim() || callback.threadTitle,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -559,6 +559,34 @@ function toConversationTargetFromCommand(ctx: PluginCommandContext): Conversatio
   return null;
 }
 
+function normalizeTelegramThreadId(threadId: string | number | undefined): number | undefined {
+  if (typeof threadId === "number") {
+    return Number.isFinite(threadId) ? threadId : undefined;
+  }
+  if (typeof threadId === "string") {
+    const parsed = Number(threadId);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function buildTelegramTopicConversationId(
+  conversationId: string | undefined,
+  threadId: number | undefined,
+): string | undefined {
+  if (!conversationId) {
+    return undefined;
+  }
+  if (threadId == null) {
+    return conversationId;
+  }
+  const topicSeparator = ":topic:";
+  const baseConversationId = conversationId.includes(topicSeparator)
+    ? conversationId.split(topicSeparator)[0]
+    : conversationId;
+  return `${baseConversationId}:topic:${threadId}`;
+}
+
 function toConversationTargetFromInbound(event: {
   channel: string;
   accountId?: string;
@@ -573,6 +601,7 @@ function toConversationTargetFromInbound(event: {
   }
   const channel = event.channel.trim().toLowerCase();
   const conversationIdRaw = event.conversationId?.trim();
+  const telegramThreadId = normalizeTelegramThreadId(event.threadId);
   const conversationId =
     channel === "discord"
       ? (() => {
@@ -588,10 +617,18 @@ function toConversationTargetFromInbound(event: {
           const isChannel = Boolean(event.parentConversationId?.trim() || event.isGroup || guildId);
           return `${isChannel ? "channel" : "user"}:${normalized}`;
         })()
+      : channel === "telegram"
+        ? buildTelegramTopicConversationId(
+            normalizeTelegramChatId(conversationIdRaw),
+            telegramThreadId,
+          )
       : event.conversationId;
   const parentConversationId =
     channel === "discord"
       ? normalizeDiscordConversationId(event.parentConversationId)
+      : channel === "telegram" && telegramThreadId != null
+        ? normalizeTelegramChatId(event.parentConversationId) ??
+          normalizeTelegramChatId(conversationIdRaw)?.split(":topic:")[0]
       : event.parentConversationId;
   if (!conversationId) {
     return null;
@@ -604,13 +641,7 @@ function toConversationTargetFromInbound(event: {
     threadId:
       channel === "discord"
         ? undefined
-        : typeof event.threadId === "number"
-          ? event.threadId
-          : typeof event.threadId === "string"
-            ? Number.isFinite(Number(event.threadId))
-              ? Number(event.threadId)
-              : undefined
-            : undefined,
+        : telegramThreadId,
   };
 }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2257,7 +2257,15 @@ export class CodexPluginController {
       if (!binding || !conversation) {
         return { text: "Bind this conversation to Codex before changing status settings." };
       }
-      const { state: currentThreadState, effectiveState } = await this.readEffectiveThreadState(binding);
+      const {
+        binding: currentBinding,
+        state: currentThreadState,
+        effectiveState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        return { text: "Bind this conversation to Codex before changing status settings." };
+      }
+      binding = currentBinding;
       const effectiveModel =
         parsed.requestedModel?.trim() ||
         (await this.resolveCurrentModelHint(binding, effectiveState));
@@ -2391,10 +2399,12 @@ export class CodexPluginController {
   }
 
   private async readEffectiveThreadState(binding: StoredBinding): Promise<{
+    binding: StoredBinding | null;
     state: ThreadState | undefined;
     effectiveState: ThreadState | undefined;
   }> {
     const profile = this.getPermissionsMode(binding);
+    let bindingCleared = false;
     const state = await this.client.readThreadState({
       profile,
       sessionKey: binding.sessionKey,
@@ -2402,11 +2412,16 @@ export class CodexPluginController {
     }).catch(async (error) => {
       if (shouldClearBindingForThreadError(error)) {
         await this.clearStaleBinding(binding, "read effective thread state");
+        bindingCleared = true;
       }
       return undefined;
     });
-    const desired = buildDesiredThreadConfiguration(state, binding);
+    const currentBinding =
+      this.store.getBinding(this.toConversationTarget(binding.conversation)) ??
+      (bindingCleared ? null : binding);
+    const desired = buildDesiredThreadConfiguration(state, currentBinding);
     return {
+      binding: currentBinding,
       state,
       effectiveState: desired.effectiveState,
     };
@@ -2564,10 +2579,13 @@ export class CodexPluginController {
     conversation: ConversationTarget,
     binding: StoredBinding,
   ): Promise<PluginInteractiveButtons> {
-    const { effectiveState } = await this.readEffectiveThreadState(binding);
-    const currentModel = await this.resolveCurrentModelHint(binding, effectiveState);
+    const { binding: currentBinding, effectiveState } = await this.readEffectiveThreadState(binding);
+    if (!currentBinding) {
+      return [];
+    }
+    const currentModel = await this.resolveCurrentModelHint(currentBinding, effectiveState);
     const currentReasoning = normalizeReasoningEffort(
-      effectiveState?.reasoningEffort ?? binding.preferences?.preferredReasoningEffort,
+      effectiveState?.reasoningEffort ?? currentBinding.preferences?.preferredReasoningEffort,
     );
     const [showModelPicker, showReasoningPicker, togglePermissions, compactThread, stopRun, refreshStatus, detachThread, showSkills, showMcp] = await Promise.all([
       this.store.putCallback({
@@ -3281,8 +3299,16 @@ export class CodexPluginController {
     if (typeof action === "object") {
       return { text: action.error };
     }
+    const {
+      binding: currentBinding,
+      state: threadState,
+      effectiveState,
+    } = await this.readEffectiveThreadState(binding);
+    if (!currentBinding) {
+      return { text: "Bind this conversation to a Codex thread before toggling fast mode." };
+    }
+    binding = currentBinding;
     const profile = this.getPermissionsMode(binding);
-    const { state: threadState, effectiveState } = await this.readEffectiveThreadState(binding);
     const currentModel =
       effectiveState?.model?.trim() || binding.preferences?.preferredModel?.trim() || undefined;
     if (!modelSupportsFast(currentModel)) {
@@ -5559,9 +5585,17 @@ export class CodexPluginController {
         await responders.reply("No Codex binding for this conversation.");
         return;
       }
-      const profile = this.getPermissionsMode(binding);
-      const { state: threadState, effectiveState } = await this.readEffectiveThreadState(binding);
-      const currentModel = await this.resolveCurrentModelHint(binding, effectiveState);
+      const {
+        binding: currentBinding,
+        state: threadState,
+        effectiveState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
+      const profile = this.getPermissionsMode(currentBinding);
+      const currentModel = await this.resolveCurrentModelHint(currentBinding, effectiveState);
       if (!modelSupportsFast(currentModel)) {
         await responders.reply(
           `Fast mode is unavailable for ${currentModel ?? "the current model"}. Use a GPT-5.4+ model to enable it.`,
@@ -5576,8 +5610,8 @@ export class CodexPluginController {
       if (threadState) {
         updatedState = await this.client.setThreadServiceTier({
           profile,
-          sessionKey: binding.sessionKey,
-          threadId: binding.threadId,
+          sessionKey: currentBinding.sessionKey,
+          threadId: currentBinding.threadId,
           serviceTier: nextTier,
         }).catch((error) => {
           if (isMissingThreadError(error)) {
@@ -5588,9 +5622,9 @@ export class CodexPluginController {
       }
       const preferredServiceTier = preferredServiceTierFromRequest(nextTier);
       const updatedBinding: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         preferences: {
-          ...(binding.preferences ?? {
+          ...(currentBinding.preferences ?? {
             preferredServiceTier: null,
             updatedAt: Date.now(),
           }),
@@ -5725,9 +5759,16 @@ export class CodexPluginController {
         return;
       }
       const active = this.activeRuns.get(buildConversationKey(callback.conversation));
-      const { state: currentThreadState } = await this.readEffectiveThreadState(binding);
+      const {
+        binding: currentBinding,
+        state: currentThreadState,
+      } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
       const updatedBindingBase: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         permissionsMode: active ? currentProfile : nextProfile,
         pendingPermissionsMode: active ? nextProfile : undefined,
         updatedAt: Date.now(),
@@ -6001,14 +6042,18 @@ export class CodexPluginController {
         await responders.reply("No Codex binding for this conversation.");
         return;
       }
-      const profile = this.getPermissionsMode(binding);
-      const { state: threadState } = await this.readEffectiveThreadState(binding);
+      const { binding: currentBinding, state: threadState } = await this.readEffectiveThreadState(binding);
+      if (!currentBinding) {
+        await responders.reply("No Codex binding for this conversation.");
+        return;
+      }
+      const profile = this.getPermissionsMode(currentBinding);
       let state = threadState;
       if (threadState) {
         state = await this.client.setThreadModel({
           profile,
-          sessionKey: binding.sessionKey,
-          threadId: binding.threadId,
+          sessionKey: currentBinding.sessionKey,
+          threadId: currentBinding.threadId,
           model: callback.model,
         }).catch((error) => {
           if (isMissingThreadError(error)) {
@@ -6018,23 +6063,23 @@ export class CodexPluginController {
         });
       }
       const nextPreferredServiceTier = modelSupportsFast(callback.model)
-        ? binding.preferences?.preferredServiceTier ?? null
+        ? currentBinding.preferences?.preferredServiceTier ?? null
         : "default";
       let nextState = state;
       if (!modelSupportsFast(callback.model) && normalizeServiceTier(state?.serviceTier) === "fast") {
         nextState = await this.client
           .setThreadServiceTier({
             profile,
-            sessionKey: binding.sessionKey,
-            threadId: binding.threadId,
+            sessionKey: currentBinding.sessionKey,
+            threadId: currentBinding.threadId,
             serviceTier: null,
           })
           .catch(() => ({ ...state, serviceTier: "default" } as ThreadState));
       }
       const updatedBinding: StoredBinding = {
-        ...binding,
+        ...currentBinding,
         preferences: {
-          ...(binding.preferences ?? {
+          ...(currentBinding.preferences ?? {
             preferredServiceTier: null,
             updatedAt: Date.now(),
           }),

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -367,4 +367,56 @@ describe("state store", () => {
       updatedAt: pendingBindUpdatedAt,
     });
   });
+
+  it("removes matching conversation callbacks without touching other kinds", async () => {
+    const store = await makeStore();
+    const conversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:456",
+      parentConversationId: "123",
+    } as const;
+    const otherConversation = {
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "123:topic:789",
+      parentConversationId: "123",
+    } as const;
+    const resumeA = await store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-1",
+      workspaceDir: "/tmp/work",
+    });
+    const resumeB = await store.putCallback({
+      kind: "resume-thread",
+      conversation,
+      threadId: "thread-2",
+      workspaceDir: "/tmp/work",
+    });
+    const pickerView = await store.putCallback({
+      kind: "picker-view",
+      conversation,
+      view: {
+        mode: "threads",
+        includeAll: false,
+        page: 0,
+      },
+    });
+    const otherResume = await store.putCallback({
+      kind: "resume-thread",
+      conversation: otherConversation,
+      threadId: "thread-3",
+      workspaceDir: "/tmp/other",
+    });
+
+    await store.removeConversationCallbacks(conversation, {
+      kinds: ["resume-thread"],
+    });
+
+    expect(store.getCallback(resumeA.token)).toBeNull();
+    expect(store.getCallback(resumeB.token)).toBeNull();
+    expect(store.getCallback(pickerView.token)?.kind).toBe("picker-view");
+    expect(store.getCallback(otherResume.token)?.kind).toBe("resume-thread");
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -683,6 +683,30 @@ export class PluginStateStore {
     this.snapshot.callbacks = this.snapshot.callbacks.filter((entry) => entry.token !== token);
     await this.save();
   }
+
+  async removeConversationCallbacks(
+    conversation: ConversationTarget,
+    params?: {
+      kinds?: CallbackAction["kind"][];
+      excludeToken?: string;
+    },
+  ): Promise<void> {
+    const conversationKey = toConversationKey(conversation);
+    const allowedKinds = params?.kinds ? new Set(params.kinds) : null;
+    this.snapshot.callbacks = this.snapshot.callbacks.filter((entry) => {
+      if (params?.excludeToken && entry.token === params.excludeToken) {
+        return true;
+      }
+      if (toConversationKey(entry.conversation) !== conversationKey) {
+        return true;
+      }
+      if (allowedKinds && !allowedKinds.has(entry.kind)) {
+        return true;
+      }
+      return false;
+    });
+    await this.save();
+  }
 }
 
 export function buildPluginSessionKey(threadId: string): string {


### PR DESCRIPTION
Fixes #108
Related: openclaw/openclaw#70288

## Summary

- **Telegram DM `parentConversationId` key mismatch**: `toConversationTargetFromInbound` was passing `event.parentConversationId` through for all Telegram channels, including DMs. For DMs (no topic), this produced an inbound key with a trailing user-ID component that never matched bindings stored at bind time. Fix: set `parentConversationId = undefined` when `channel === "telegram"` and no thread/topic exists.

- **Stale OpenClaw binding cleanup**: When the plugin's internal thread state is cleared without properly detaching from OpenClaw's session binding registry, subsequent inbound messages find `resolvedBinding === null` but OpenClaw still routes them to this plugin. Previously the plugin returned `{ handled: false }`, silently falling through to the LLM. Fix: check OpenClaw's session binding service for an active binding, unbind it, and notify the user (`⚠️ Codex session expired. Run /cas_resume to start a new thread.`), then return `{ handled: true }`.

## Context

The `parentConversationId` regression was introduced by the PR-96 Telegram topic support merge, which added Telegram-specific handling but left the DM path passing the raw event value through.

The stale binding issue surfaces most visibly once the key mismatch is fixed — previously DM messages never claimed the binding at all, so the stale path was unreachable.

Both fixes are needed alongside the OpenClaw core fix in openclaw/openclaw#70288, which ensures that when a plugin returns `{ handled: true }` from `inbound_claim`, the channel handler does not fire a silent `NO_REPLY` fallback before the plugin's async response arrives.

## Validation

- Telegram DM with active session: message correctly claimed, Codex responds
- Telegram DM after session expiry/restart: stale binding detected, user notified, LLM fallback suppressed
- Telegram topic thread: existing behavior unchanged
- Discord: unaffected